### PR TITLE
Support localization to other languages.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,7 +111,16 @@ collections:
     output: true
     permalink: /:path/
 
-permalink: pretty
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      lang: en
+
+permalink: /:lang/:categories/:year/:month/:day/:title/
+permalink_custom_vars:
+  - lang
 
 markdown: kramdown
 plugins:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@ The home page uses wide.html layout, since it extends full width of page
 
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="{{ page.lang }}">
 
 {% include meta.html %}
 

--- a/_plugins/jekyll_parse_language.rb
+++ b/_plugins/jekyll_parse_language.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  class JekyllParseLanguage < Generator
+    def generate(site)
+      site.posts.docs.each do |post|
+        matches = post.basename_without_ext.match(/^(.*)\.lang-([A-z]{2})$/)
+        if matches
+          post.data['slug'] = matches[1]
+          post.data['lang'] = matches[2]
+        end
+      end
+    end
+  end
+end

--- a/_plugins/jekyll_permalink_custom_vars.rb
+++ b/_plugins/jekyll_permalink_custom_vars.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  class JekyllPermalinkCustomVars < Generator
+    def generate(site)
+      site.posts.docs.each do |post|
+        post.data['permalink'] = site.config['permalink'].dup unless post.data.key?('permalink')
+
+        site.config['permalink_custom_vars'].each do |var|
+          post.data['permalink'].gsub! ":#{var}", post.data[var].to_s or ''
+        end
+      end
+    end
+  end
+end

--- a/_posts/2019-01-13-an-extra.lang-en.md
+++ b/_posts/2019-01-13-an-extra.lang-en.md
@@ -8,7 +8,7 @@ tag: about, highrisk
 promoted: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus interdum pellentesque. Integer eu vehicula elit. Sed cursus magna in dui suscipit rhoncus.
+English version - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus interdum pellentesque. Integer eu vehicula elit. Sed cursus magna in dui suscipit rhoncus.
 
 Curabitur sed elit viverra, fermentum massa non, hendrerit ex. Vivamus eget mattis tortor, eu elementum sapien. Praesent elementum feugiat nisi venenatis vestibulum. Nulla pretium ipsum orci, ut feugiat arcu facilisis sit amet.
 

--- a/_posts/2019-01-13-an-extra.lang-es.md
+++ b/_posts/2019-01-13-an-extra.lang-es.md
@@ -1,0 +1,15 @@
+---
+title: Test tagged post
+layout: post
+date: January 13, 2019
+author: Author
+excerpt: This is an excerpt
+tag: about, highrisk
+promoted: true
+---
+
+Spanish version - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus interdum pellentesque. Integer eu vehicula elit. Sed cursus magna in dui suscipit rhoncus.
+
+Curabitur sed elit viverra, fermentum massa non, hendrerit ex. Vivamus eget mattis tortor, eu elementum sapien. Praesent elementum feugiat nisi venenatis vestibulum. Nulla pretium ipsum orci, ut feugiat arcu facilisis sit amet.
+
+Morbi bibendum est non nibh aliquam, non dictum massa elementum. Nullam vitae auctor erat. Mauris at arcu ut purus sodales porttitor ut sit amet ex. Donec viverra quam nisl, a congue arcu fermentum rhoncus.


### PR DESCRIPTION
This will enable us to have localized content: 

- Append `.lang-{2 character language code}` to post files to indicate their language. 
- This creates a `/{2 character language code}/` output directory in the site folder.
- We can use `{{ post.lang }}` in files to reference the current language and link to the right language in URLs.
- The default language is `en` for files without the suffix.

This approach keeps each translation next to each other in directories, and allows us to filter based on `post.lang` on pages.