### PR TITLE
Initial DAP setup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ twitter: 18F
 google_analytics_ua: UA-????????-??
 
 
-dap_agency: GSA
+dap_agency: HHS
 # USAID   - Agency for International Development
 # USDA    - Department of Agriculture
 # DOC     - Department of Commerce

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -37,9 +37,5 @@ site, this is the place to do it.
   <!-- CSS
     ================================================== -->
 
-  <!-- DAP -->
-  <script async type="text/javascript" id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=HHS&subagency=CDC"></script>
-
   {% asset index.scss %}
 </head>


### PR DESCRIPTION
Retracting #9 to leverage template's provided DAP. Leaving off `sub_agency` for now.