### PR TITLE
Don't shadow the container's node_modules directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "4000:4000"
     volumes:
       - .:/app
+      - /app/node_modules


### PR DESCRIPTION
Adds a line to the `docker-compose.yml` to instruct Docker to preserve the `node_modules` directory in the container rather than replacing it with the one from the mounted volume.