### PR TITLE
Don't shadow the container's node_modules directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
       - /app/.jekyll-cache/  # do not sync to host fs for performance reasons
       - /app/_site/          # do not sync to host fs for performance reasons
       - /app/_site_assets/   # do not sync to host fs for performance reasons
+      - /app/node_modules


### PR DESCRIPTION
Adds a line to the `docker-compose.yml` to instruct Docker to preserve the `node_modules` directory in the container rather than replacing it with the one from the mounted volume.