### PR TITLE
Generate unique, descriptive page titles sitewide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@
 # Be sure to edit the values below
 ##########################################################################################
 
-title: CDC
+title: CDC COVID-19 Answers
 logo_alt: Centers for Disease Control and Prevention. CDC twenty four seven. Saving Lives, Protecting People
 email: contact@example.gov
 description: >- # this means to ignore newlines until "baseurl:"

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,8 +16,8 @@ site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Title and meta description
     ================================================== -->
-  <title>{{site.title}}</title>
-  <meta property="og:title" content="{{site.title}}">
+  <title>{% if page.title %}{{ page.title }} - {{site.title}}{% else %}{{site.title}}{% endif %}</title>
+  <meta property="og:title" content="{% if page.title %}{{ page.title }} - {{site.title}}{% else %}{{site.title}}{% endif %}">
   <meta name="description" content="{{site.description}}">
   <meta property="og:description" content="{{site.description}}">
 


### PR DESCRIPTION
This PR sets up a convention to ensure that accessible, unique, and descriptive page titles are generated across the site. The `meta.html` file pulls the title from the `page.title` and appends the `site.title` to the end. If there is no `page.title`, then the fallback is the `site.title` from the `config.yml`.

Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>