### PR TITLE
remove alt on decorative icons within links

### DIFF
--- a/_includes/top-questions.html
+++ b/_includes/top-questions.html
@@ -6,7 +6,7 @@
       <a class="question" href="{{ question.link | relative_url }}">
         <div class="icon margin-right-2">
           {% capture icon_path %}icons/{{ question.icon }}.svg{% endcapture %}
-          {% asset '{{ icon_path }}' class="" alt="{{ question.icon }} icon" %}
+          {% asset '{{ icon_path }}' class="" alt="" %}
         </div>
 
         <span>{{ question.question }}</span>


### PR DESCRIPTION
VoiceOver was reading out the title of the icon + "icon" and then the link text (question.title) which was too verbose. 


Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>