### PR TITLE
Remove browser's autocomplete

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -2,7 +2,7 @@
   <div role="search" class="grid-row">
     <div class="grid-col">
       <label class="usa-label usa-sr-only" for="search-box">Search CDC for information on COVID-19</label>
-      <input class="usa-input" id="search-box" name="query" type="search"
+      <input class="usa-input" id="search-box" autocomplete="off" name="query" type="search"
         placeholder="Search questions, keywords, or topics to find answers" />
     </div>
     <div class="grid-col-auto">


### PR DESCRIPTION
If the site will use JS to autocomplete, then we should disable the browser's built in support because they collide if both are enabled.