### PR TITLE
Allow for customizing of search placeholder w/ include

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -15,7 +15,7 @@
       <h1 class="grid-col-12">{{ include.hero.title }}</h1>
     </div>
     <div  class="usa-search">
-      {% include search.html %}
+      {% include search.html placeholder = "Search questions, keywords, or topics to find answers" %}
     </div>
     <div class="grid-row">
       <p class="hero--tagline grid-col-12">or you can browse the categories below to find what you are looking for.</p>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -16,7 +16,7 @@ where we provide an easy way to manage your navigation system
     </div>
       {% if page.url != '/'' %}
       <div class="grid-col-12 tablet:grid-col-6 padding-y-2 tablet:padding-x-2 menu-search">
-        {% include search.html %}
+        {% include search.html placeholder="Search questions, keywords, or topics" %}
       </div>
       {% endif %}
   </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -4,7 +4,7 @@
       <label class="usa-label usa-sr-only" for="search-box">Search CDC for information on COVID-19</label>
       <div class="autocomplete_container">
         <input class="usa-input height-full" id="search-box" autocomplete="off" name="query" type="search"
-          placeholder="Search questions, keywords, or topics to find answers" />
+          placeholder="{{ include.placeholder }}" />
       </div>
     </div>
     <div class="grid-col-auto">


### PR DESCRIPTION
Targetted `menu-search-less-round` branch.

Moving search `placeholder` text into a variable and trimming content for search input rendered in menu.

<img width="432" alt="Screen Shot 2020-03-19 at 8 59 03 AM" src="https://user-images.githubusercontent.com/3485564/77070077-f519cc00-69bf-11ea-8cec-a13814eeceed.png">
