### PR TITLE
Change no results message.

### DIFF
--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -145,7 +145,7 @@
         suggestion: (item) => highlight(item.title)
       },
       tNoResults: () => {
-        return runningRequest ?  'Loading…' : 'No results found';
+        return runningRequest ? 'Loading…' : `No results for “${newInput.value}”`;
       },
       source: (query, populateResults) => {
         const thisRequest = makeDebouncedRequest(query, (results) => {


### PR DESCRIPTION
Fixes #139.

This PR changes the `No results found` message to `No results for “your query”`. 

Caveat, also noted in the upstream issue: I wasn’t able to put the query text in bold, as is defined in the design specs. The autocomplete library we’re using prevents using HTML in this section, as it can result in a security issue (self-XSS). 