### PR TITLE
Use local search for typeahead.

### DIFF
--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -125,7 +125,7 @@
     let runningRequest = null;
 
     const makeDebouncedRequest = debounce((query, completed) => {
-      window.SearchService(query)
+      search_local(query)
         .then(results => completed(results.slice(0, 5)));
     }, 300);
 


### PR DESCRIPTION
This is the working implementation of typeahead using local search, which fixes the concern about the number of queries being sent to search.gov. 

This is in conflict with a typeahead that is based on the term suggestion API, and will need to be a product choice.