### PR TITLE
header tweaks

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,7 @@ This template is for a single page that does not have a date associated with it.
       {% include sidenav.html %}
       {% endif %}
 
-      <div class="usa-layout-docs__main desktop:grid-col-12 usa-prose">
+      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
         {{ content }}
       </div>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,10 +9,10 @@ This is used in blog posts. The index page can be found at blog/index.html
 <div class="usa-layout-docs usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="usa-layout-docs__main desktop:grid-col-12 usa-prose">
+      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
         <div class="usa-accordion usa-accordion--bordered" aria-multiselectable=true>
           {% include accordion.html accordion_content=page %}
-        </div>
+         </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Current design:
<img width="1617" alt="Screen Shot 2020-03-20 at 9 52 12 AM" src="https://user-images.githubusercontent.com/509309/77181487-0383e880-6a91-11ea-99ee-d1a433861808.png">

looks funky because the accordion isn't 12 col but 9, but even at 12, the logos don't _seem_ to be centered (even though they are, taking into account margin and padding -- I think it has to do with the disparate shapes):
<img width="1544" alt="Screen Shot 2020-03-20 at 10 00 49 AM" src="https://user-images.githubusercontent.com/509309/77182012-b8b6a080-6a91-11ea-9ca9-b8c38068b538.png">


Here's another option:
<img width="1387" alt="Screen Shot 2020-03-20 at 9 55 19 AM" src="https://user-images.githubusercontent.com/509309/77181784-71c8ab00-6a91-11ea-8765-22e9c5f3b538.png">
