### PR TITLE
Improve search by looking further into pages.

### DIFF
--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -92,7 +92,8 @@
     searchjson
       .then(pages => {
         return new Fuse(pages, {
-          keys: ["title", "excerpt", "content"]
+          keys: ["title", "excerpt", "content"],
+          distance: 1000
         }).search(query);
       })
       .then(translate_fromSearchJson)


### PR DESCRIPTION
`distance` indicates how far into the strings (title, body) of a page to read when looking for search results. It defaults to `100` characters, this PR shifts it to the first `1000` characters. 