### PR TITLE
Update source link in social distancing FAQ

### DIFF
--- a/_content/basics/what-is-social-distancing.md
+++ b/_content/basics/what-is-social-distancing.md
@@ -5,7 +5,7 @@ layout: post
 date: March 18, 2020
 source: CDC
 promoted: true
-source_url: https://webcache.googleusercontent.com/search?q=cache:_WT1yjb8w94J:https://www.cdc.gov/coronavirus/2019-ncov/about/coping.html+&cd=6&hl=en&ct=clnk&gl=us and https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html
+source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html
 excerpt: About COVID-19
 ---
 


### PR DESCRIPTION
Updated broken source link for social distancing. Since that link changed on the CDC website replaced it with a link to a travel FAQ that includes information about social distancing. 

I thought this might be more reliable than link to CDC Facebook content (https://www.facebook.com/CDC/videos/492811354934260/) that might change. 