### PR TITLE
Ignore empty alt tags.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "bundle exec jekyll clean",
     "start": "npm run start:site",
     "start:site": "bundle exec jekyll serve --host 0.0.0.0",
-    "test": "npm run build && bundle exec htmlproofer _site && npx a11y '_site/**/*.html'"
+    "test": "npm run build && bundle exec htmlproofer _site --empty-alt-ignore && npx a11y '_site/**/*.html'"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.2",


### PR DESCRIPTION
Fixes #200.

As confirmed via Robert, these images are not meaningful content and should not have alt tags.

This PR allows `npm test` to pass successfully, which allows us to enable CI. 

Enabling CI will give us broken URLs when links on the generated site (including links to our sources) return 404s.