### PR TITLE
resolves #185

### DIFF
--- a/_content/protect-yourself/how-many-cases-are-there-in-the-us.md
+++ b/_content/protect-yourself/how-many-cases-are-there-in-the-us.md
@@ -1,0 +1,12 @@
+---
+title: How many cases are there in the U.S.?
+category: protect-yourself
+layout: post
+date: March 21, 2020
+source: CDC
+promoted: false
+source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#protect
+excerpt: How to protect yourself
+---
+
+There are several cases of COVID-19 in the U.S. related to travel and through close contact. U.S. case counts are updated regularly Mondays through Fridays. See the <a href="https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/cases-in-us.html?CDC_AA_refVal=https%3A%2F%2Fwww.cdc.gov%2Fcoronavirus%2F2019-ncov%2Fcases-in-us.html"> current U.S. case count of COVID-19</a>

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,7 +49,7 @@ questions_box_1:
 questions_box_2:
   questions:
     - link: >-
-        /symptoms-and-testing/#what-are-the-symptoms-and-complications-that-covid-19-can-cause
+        /symptoms-and-testing/what-are-the-symptoms-and-complications-that-covid-19-can-cause
       question: What are the symptoms of COVID-19?
     - link: '/symptoms-and-testing/should-i-be-tested-for-covid-19'
       question: Should I get tested?

--- a/_site/index.html
+++ b/_site/index.html
@@ -1,0 +1,529 @@
+
+
+<!DOCTYPE html>
+
+<html lang="en">
+
+
+
+<head>
+  <!-- Basic Page Needs
+    ================================================== -->
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="googlebot" content="noindex, nofollow">
+  <meta name="bingbot" content="noindex, nofollow">
+  <!-- Mobile Specific Metas
+    ================================================== -->
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Title and meta description
+    ================================================== -->
+  <title>Find answers about COVID-19 - CDC COVID-19 Answers</title>
+  <meta property="og:title" content="Find answers about COVID-19 - CDC COVID-19 Answers">
+  <meta name="description" content="CDC works 24/7 to protect America from health, safety and security threats">
+  <meta property="og:description" content="CDC works 24/7 to protect America from health, safety and security threats">
+
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@CDCgov" />
+  <meta name="twitter:title" content="CDC COVID-19 Answers" />
+  <meta name="twitter:description" content="CDC works 24/7 to protect America from health, safety and security threats" />
+
+  <meta name="baseurl" content="">
+  <meta name="searchgov_endpoint" content="https://search.usa.gov">
+  <meta name="searchgov_affiliate" content="18fcvddev">
+  <meta name="searchgov_access_key" content="yBQhiqQjR80tDwx5HuPvbluq4NgkO_RTwludGJAPgwg=">
+
+  <meta property="og:type" content="article">
+  <link rel="canonical" href="/">
+  <meta property="og:url" content="/">
+  <!-- Favicons
+    ================================================== -->
+  <!-- 128x128 -->
+  <link rel="shortcut icon" type="image/ico" href="/assets/cdc-favicon-2f0a6fe0e824262821cc359a15b7908a00e5733fb6d8a5cdd404a7ad94988e47.ico">
+
+  <!-- CSS
+    ================================================== -->
+
+  <link rel="stylesheet" type="text/css" href="/assets/index-64237feb76f62ca3b8688d8d0758905bac6db372ba961a85c3a9aca7d2f1b070.css">
+</head>
+
+
+<body>
+  
+
+<div class="page-landing-page layout-demo ">
+  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner__header" aria-label="Official badge">
+        <div class="usa-banner__inner">
+          <div class="grid-col-auto">
+            <img class="usa-banner__header-flag" alt="U.S. flag" src="/assets/us_flag_small-8a6f68dd8703ce4cb475c92fc1eefa84c41f4741ec4c6ca8403ef99b74b94d20.png">
+          </div>
+          <div class="grid-col-fill tablet:grid-col-auto">
+            <p class="usa-banner__header-text">An official website of the United States government</p>
+            <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+          </div>
+          <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner__button-text">Here's how you know</span>
+          </button>
+        </div>
+      </header>
+      <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+        <div class="grid-row grid-gap-lg">
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img class="usa-banner__icon usa-media-block__img" alt="Dot gov" src="/assets/icon-dot-gov-8d5d08018c88ad2fa2608e080ee8d7b994fce4ce311bc65077a95469355bdd04.svg">
+            <div class="usa-media-block__body">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure
+                you’re on a federal government site.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img class="usa-banner__icon usa-media-block__img" alt="Https" src="/assets/icon-https-c4fbe61cb398b85c01cd675f6a554f1845bc342f568b59297de3c126a5e7f5f8.svg">
+            <div class="usa-media-block__body">
+              <p>
+                <strong>The site is secure.</strong>
+                <br>
+                The <strong>https://</strong> ensures that you are connecting to the official website and that any
+                information you provide is encrypted and transmitted securely.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="usa-overlay"></div>
+</div>
+
+  
+
+<header class="usa-header usa-header--extended" role="banner" aria-label="primary site header">
+  <div class="usa-navbar grid-container">
+    <div class="grid-row">
+      <div class="grid-col-12 tablet:grid-col-6">
+        <div class="usa-logo" id="extended-logo">
+  <em class="usa-logo__text"><a href="/" title="Home"
+      aria-label="Home"><img alt="Centers for Disease Control and Prevention. CDC twenty four seven. Saving Lives, Protecting People" src="/assets/cdc-logo-a302c015781daefb75fd251534cb1ca91ad8db72302f3c687a6db6ddef10c415.svg"></a></em>
+</div>
+      </div>
+      <div class="grid-col-12 tablet:grid-col-6">
+        
+      </div>
+    </div>
+  </div>
+</header>
+
+  
+  <main id="main-content">
+    
+
+
+  <div class="usa-alert usa-alert--warning" >
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading"><a href="https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/summary.html#cdc-response">See how CDC is responding to COVID-19 and the coronavirus that causes it</a>.</h3>
+      <p class="usa-alert__text"></p>
+    </div>
+  </div>
+
+<section class="usa-hero hero__no-image">
+  <div class="grid-container">
+    <div class="grid-row">
+      
+      <h1 class="grid-col-12">Find answers about COVID-19</h1>
+    </div>
+    <div  class="usa-search">
+      <form id="search_form" action="/search/">
+  <div role="search" class="grid-row">
+    <div class="grid-col">
+      <label class="usa-label usa-sr-only" for="search-box">Search CDC for information on COVID-19</label>
+      <input class="usa-input" id="search-box" autocomplete="off" name="query" type="search"
+        placeholder="Search questions, keywords, or topics to find answers" />
+    </div>
+    <div class="grid-col-auto">
+      <button class="usa-button" type="submit">
+        <span class="usa-search__submit-text">Search</span>
+      </button>
+    </div>
+  </div>
+</form>
+
+    </div>
+    <div class="grid-row">
+      <p class="hero--tagline grid-col-12">or you can browse the categories below to find what you are looking for.</p>
+    </div>
+  </div>
+</section>
+<section class="grid-container usa-section usa-prose top-questions usa-section--condensed">
+  <h2>Top questions</h2>
+  <div class="grid-row grid-gap">
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/symptoms-and-testing/#what-are-the-symptoms-and-complications-that-covid-19-can-cause'">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="stethoscope icon" src="/assets/icons/stethoscope-0d5cbf1dcff669289ec8ccd865d9c8a8c4db845f87ef5d434085d5b6844578bb.svg">
+        </div>
+
+        <span>What are the symptoms?</span>
+      </a>
+    </div>
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/symptoms-and-testing/#should-i-be-tested-for-covid-19">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="test icon" src="/assets/icons/test-475d407641ebeb6a1254d1018499468cf2beac43cceb44af6a37a2dd4ec79f9a.svg">
+        </div>
+
+        <span>Should I get tested?</span>
+      </a>
+    </div>
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/spread/how-does-the-virus-spread">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="chart icon" src="/assets/icons/chart-814ae1d1055b8ca69e8bcc898d445c7c701443822beb19016e1ce98a809b7a01.svg">
+        </div>
+
+        <span>How does it spread?</span>
+      </a>
+    </div>
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/basics/what-is-social-distancing">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="group icon" src="/assets/icons/group-c4e392134cc8401eeb144f54f5d873b36d0a8107dffa02dca56bf9e260324394.svg">
+        </div>
+
+        <span>What is social distancing?</span>
+      </a>
+    </div>
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/protect-yourself/#how-many-cases-are-there-in-the-us">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="globe icon" src="/assets/icons/globe-ede5bec1d576340a40340f08760cd889b9ac1243064020c6d953f36ecaaad527.svg">
+        </div>
+
+        <span>Cases in the U.S.</span>
+      </a>
+    </div>
+    
+    <div class="tablet:grid-col-6 desktop:grid-col-4">
+      <a class="question" href="/travel/">
+        <div class="icon margin-right-2">
+          
+          <img class="" alt="plane icon" src="/assets/icons/plane-d5894cdb31074c92db6934667c5a896965841ae524b7e49101cb6bf6313bb4d0.svg">
+        </div>
+
+        <span>Can I travel?</span>
+      </a>
+    </div>
+    
+  </div>
+</section>
+
+
+
+<section class="grid-container usa-section usa-prose usa-section--condensed border-top border-base-lightest">
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col-6 flex-align-stretch margin-bottom-2">
+      <div class="question-box question-box--info">
+        <h2>How to protect yourself</h2>
+        <ul class="usa-list usa-list--unstyled">
+          
+          <li class="padding-y-1">
+            <a href="/basics/steps-to-prevent-the-illness">
+              What are the steps to prevent the illness?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="/protect-yourself/">
+              Am I at risk?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="https://www.cdc.gov/coronavirus/2019-ncov/community/index.html">
+              How can I protect others?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/managing-stress-anxiety.html">
+              How can I manage anxiety and stress?
+            </a>
+          </li>
+          
+        </ul>
+        <a href="/protect-yourself/" class="text-bold text-underline margin-y-1">View all <span class="usa-sr-only">questions about </span><span aria-hidden="true">»</span></a>
+      </div>
+
+    </div>
+
+    <div class="tablet:grid-col-6 flex-align-stretch margin-bottom-2">
+      <div class="question-box question-box--warning">
+        <h2>What to do if you feel sick</h2>
+        <ul class="usa-list usa-list--unstyled">
+          
+          <li class="padding-y-1">
+            <a href="/symptoms-and-testing/#what-are-the-symptoms-and-complications-that-covid-19-can-cause">
+              What are the symptoms of COVID-19?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="/symptoms-and-testing/#should-i-be-tested-for-covid-19">
+              Should I get tested?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="/symptoms-and-testing/when-should-i-call-my-doctor">
+              When should I go to the doctor?
+            </a>
+          </li>
+          
+          <li class="padding-y-1">
+            <a href="https://www.cdc.gov/coronavirus/2019-ncov/hcp/guidance-prevent-spread.html#precautions">
+              How do I care for someone who’s sick?
+            </a>
+          </li>
+          
+        </ul>
+        <a href="/protect-yourself/" class="text-bold text-underline margin-y-1">View all <span class="usa-sr-only">questions about </span><span aria-hidden="true">»</span></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="grid-container usa-section usa-section--condensed border-top border-base-lightest">
+  <div class="grid-row grid-gap">
+    
+    
+
+    
+    
+    
+    <div class="usa-media-block tablet:grid-col-4 margin-bottom-3">
+      <h3>About COVID-19</h3>
+      <ul class="usa-list usa-list--unstyled">
+        
+        
+        <li class="padding-y-1">
+          <a href="/basics/#how-can-people-help-stop-stigma-related-to-covid-19">How can people help stop stigma related to COVID-19?</a>
+        </li>
+        
+        
+        
+        <li class="padding-y-1">
+          <a href="/basics/#what-is-a-novel-coronavirus">What is a novel coronavirus?</a>
+        </li>
+        
+        
+      </ul>
+      <a href="/basics/" class="text-bold text-underline margin-y-1">View all <span
+          class="usa-sr-only">questions about About COVID-19 </span><span aria-hidden="true">»</span></a>
+    </div>
+    
+    
+    
+    <div class="usa-media-block tablet:grid-col-4 margin-bottom-3">
+      <h3>How to protect yourself</h3>
+      <ul class="usa-list usa-list--unstyled">
+        
+        
+        <li class="padding-y-1">
+          <a href="/protect-yourself/#am-i-at-risk-for-covid-19-in-the-united-states">Am I at risk for COVID-19 in the United States?</a>
+        </li>
+        
+        
+        
+        <li class="padding-y-1">
+          <a href="/protect-yourself/#am-i-at-risk-for-covid-19-from-packages-or-products-shipping-from-china">Am I at risk for COVID-19 from packages or products shipping from China?</a>
+        </li>
+        
+        
+      </ul>
+      <a href="/protect-yourself/" class="text-bold text-underline margin-y-1">View all <span
+          class="usa-sr-only">questions about How to protect yourself </span><span aria-hidden="true">»</span></a>
+    </div>
+    
+    
+    
+    <div class="usa-media-block tablet:grid-col-4 margin-bottom-3">
+      <h3>Symptoms and testing</h3>
+      <ul class="usa-list usa-list--unstyled">
+        
+        
+        <li class="padding-y-1">
+          <a href="/symptoms-and-testing/#can-a-person-test-negative-and-later-test-positive-for-covid-19">Can a person test negative and later test positive for COVID-19?</a>
+        </li>
+        
+        
+        
+        <li class="padding-y-1">
+          <a href="/symptoms-and-testing/#should-i-be-tested-for-covid-19">Should I be tested for COVID-19?</a>
+        </li>
+        
+        
+      </ul>
+      <a href="/symptoms-and-testing/" class="text-bold text-underline margin-y-1">View all <span
+          class="usa-sr-only">questions about Symptoms and testing </span><span aria-hidden="true">»</span></a>
+    </div>
+    
+    
+    
+    <div class="usa-media-block tablet:grid-col-4 margin-bottom-3">
+      <h3>How it spreads</h3>
+      <ul class="usa-list usa-list--unstyled">
+        
+        
+        <li class="padding-y-1">
+          <a href="/spread/#can-someone-who-has-been-quarantined-for-covid-19-spread-the-illness-to-others">Can someone who has been quarantined for COVID-19 spread the illness to others?</a>
+        </li>
+        
+        
+        
+        <li class="padding-y-1">
+          <a href="/spread/#can-someone-who-has-had-covid-19-spread-the-illness-to-others">Can someone who has had COVID-19 spread the illness to others?</a>
+        </li>
+        
+        
+      </ul>
+      <a href="/spread/" class="text-bold text-underline margin-y-1">View all <span
+          class="usa-sr-only">questions about How it spreads </span><span aria-hidden="true">»</span></a>
+    </div>
+    
+    
+    
+    <div class="usa-media-block tablet:grid-col-4 margin-bottom-3">
+      <h3>Traveling</h3>
+      <ul class="usa-list usa-list--unstyled">
+        
+        
+        <li class="padding-y-1">
+          <a href="/travel/#are-international-layovers-included-in-cdc-s-recommendation-to-avoid-nonessential-travel">Are international layovers included in CDC's recommendation to avoid nonessential travel?</a>
+        </li>
+        
+        
+        
+        <li class="padding-y-1">
+          <a href="/travel/#how-are-travelers-from-countries-with-level-3-travel-health-notices-being-screened-when-they-enter-the-united-states">How are travelers from countries with Level 3 Travel Health Notices being screened when they enter the United States?</a>
+        </li>
+        
+        
+      </ul>
+      <a href="/travel/" class="text-bold text-underline margin-y-1">View all <span
+          class="usa-sr-only">questions about Traveling </span><span aria-hidden="true">»</span></a>
+    </div>
+    
+  </div>
+</section>
+
+  </main>
+
+  <footer class="usa-footer site-footer" role="contentinfo">
+  <div class="footer-section-bottom bg-base-darkest padding-y-2">
+    <div class="grid-container">
+      <div class="grid-row grid-gap">
+        <div class="tablet:grid-col">
+          <h3>Have Questions?</h3>
+          <ul class="icon-list">
+            <li><img class="footer-icon" alt="Desktop computer" src="/assets/icons/cdc-icon-desktop-2788c45795897ecd18385e717222f4a32cc5e4485ef8af137599e1cc138c0dd3.svg"><a
+                href="https://www.cdc.gov/cdc-info/index.html">Visit CDC-INFO</a></li>
+            <li><img class="footer-icon" alt="Phone" src="/assets/icons/cdc-icon-phone-d7b700f7c8aef5153ef7f28bd760b1627eb862054c02aca31c4805242b76e4a9.svg"><span itemprop="telephone">Call
+                800-232-4636</span></li>
+            <li><img class="footer-icon" alt="Email" src="/assets/icons/cdc-icon-email-801da11f33b6cd0bcd1eaa85952c5a5432e9d14e6498712bfc053aa146479e46.svg"><a
+                href="https://wwwn.cdc.gov/dcs/contactus/form">Email CDC-INFO</a></li>
+            <li><img class="footer-icon" alt="Open hours" src="/assets/icons/cdc-icon-hours-07bc1f99941b5beb3302564d0a211bcc6142700382be1cbc2521a92fb10e5fb5.svg"><a
+                href="https://www.cdc.gov/cdc-info/index.html">Open 24/7</a></li>
+          </ul>
+        </div>
+        <div class="tablet:grid-col">
+          <h3>CDC Information</h3>
+          <ul class="add-list-reset">
+            <li><a href="https://www.cdc.gov/about/default.htm">About CDC</a></li>
+            <li><a href="https://jobs.cdc.gov">Jobs</a></li>
+            <li><a href="https://www.cdc.gov/funding">Funding</a></li>
+            <li><a href="https://www.cdc.gov/Other/policies.html">Policies</a></li>
+            <li><a href="https://www.cdc.gov/other/plugins/index.html">File Viewers &amp; Players</a></li>
+          </ul>
+        </div>
+        <div class="tablet:grid-col">
+          <ul class="add-list-reset">
+            <li><a href="https://www.cdc.gov/other/privacy.html">Privacy</a></li>
+            <li><a href="https://www.cdc.gov/od/foia">FOIA</a></li>
+            <li><a href="https://www.cdc.gov/eeo/nofearact/index.htm">No Fear Act</a></li>
+            <li><a href="https://oig.hhs.gov">OIG</a></li>
+            <li><a href="https://www.cdc.gov/other/nondiscrimination.html">Nondiscrimination</a></li>
+            <li><a href="https://www.cdc.gov/contact/accessibility.html">Accessibility</a></li>
+          </ul>
+        </div>
+        <div class="tablet:grid-col">
+          <h3>Connect with CDC</h3>
+          <ul class="list-inline">
+            <li><a href="https://www.facebook.com/CDC" target="_blank">
+                <span class="usa-sr-only">Facebook</span>
+                <img class="footer-icon" alt="Facebook" src="/assets/icons/cdc-icon-facebook-40b580f7a263c8fa263c703dd3a1f9d5976b410a1b49421499d9b2ce5d51e981.svg">
+              </a></li>
+            <li><a href="https://twitter.com/CDCgov" target="_blank"><span class="usa-sr-only">Twitter</span>
+                <img class="footer-icon" alt="Twitter" src="/assets/icons/cdc-icon-twitter-c0ccb2bad09454b752ea8a5f76f2a0e6d144e7f3744a2144f3e0afd404b92905.svg"></a></li>
+            <li><a href="https://www.youtube.com/user/CDCstreamingHealth" target="_blank"><span
+                  class="usa-sr-only">Youtube</span>
+                <img class="footer-icon" alt="YouTube" src="/assets/icons/cdc-icon-youtube-04822a1a33587982ab436dce6c3dc0f4ac4be9a87143aef6dee310639e77473e.svg"></a></li>
+            <li><a href="https://www.instagram.com/CDCgov/" target="_blank"><span class="usa-sr-only">Instagram</span>
+                <img class="footer-icon" alt="Instagram" src="/assets/icons/cdc-icon-instagram-69eb4ee24d2c2c58cf6a3be4ceb7335769e2ccec65237285871e0bf55a4197c5.svg"></a></li>
+          </ul>
+          <ul class="list-inline">
+            <li><a href="https://tools.cdc.gov/medialibrary/index.aspx#/media/id/131979" class="footer-syndlink"><span
+                  class="usa-sr-only">Syndicate</span>
+                <img class="footer-icon" alt="Syndicate" src="/assets/icons/cdc-icon-media-library-19b1ff5a325e208b83643404772620508b65322523afbd4b66a898f5caf83c3d.svg"></a></li>
+            <li><a href="https://www.cdc.gov/cdctv"><span class="usa-sr-only">CDC TV</span>
+                <img class="footer-icon" alt="CDC TV" src="/assets/icons/cdc-icon-cdctv-ca611456906ec78b851a53ab511d8f33ff8f06d58fa9f5bc1cc9b1b4bcd4dd0d.svg"></a></li>
+            <li><a href="https://tools.cdc.gov/podcasts/rss.asp"><span class="usa-sr-only">RSS</span>
+                <img class="footer-icon" alt="RSS" src="/assets/icons/cdc-icon-rss-3d122d0fe1db87dc600eeb42de5cd506887fb6907e828bfb53f0849f4ef7c7c7.svg"></a></li>
+            <li><a href="https://wwwn.cdc.gov/dcs/RequestForm.aspx"><span class="usa-sr-only">Email</span>
+                <img class="footer-icon" alt="Email" src="/assets/icons/cdc-icon-email-801da11f33b6cd0bcd1eaa85952c5a5432e9d14e6498712bfc053aa146479e46.svg"></a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+</footer>
+<section class="disclaimer">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="grid-col-12 tablet:grid-col-6">
+        <a href="https://www.hhs.gov">U.S. Department of Health &amp; Human Services</a>
+      </div>
+      <div class="grid-col-12 tablet:grid-col">
+        <a href="https://www.usa.gov/">USA.gov</a>
+      </div>
+      <div class="grid-col-12 tablet:grid-col">
+        <a href="https://www.cdc.gov/Other/disclaimer.html" class="footer-ext">CDC Website Exit Disclaimer</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+  <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=HHS"></script>
+
+<script src="/assets/app-269afc2562ab63156daa2363d19f57fd017fd6ae908470ce8b9c9a31f036a04c.js" type="text/javascript"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Per request, removing visible focus outline from the #more-questions `div`.

To note: Focus is being kept on the div, because that is needed for screen reader users (blind and low vision folks). However, because of the state change visually, sighted keyboard-only users (typically folks with motor disabilities) will still know where they are on the page. 

I do not recommend removing any other focus outlines on the site. This one, however, should be OK to do. 