### PR TITLE
When running automated tests, don’t build the site twice.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
           key: v2-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: npm run build
       - run: npm run test
 
 


### PR DESCRIPTION
Our `test` command starts by building the site, and so it doesn't need to be called explicitly beforehand. 

An alternative implementation is to drop `npm run build` from our test command, but I (personally) prefer it to be a part of the test command to prevent issues with changing source files and re-running tests, only to have the test continue to fail (since the build hasn’t been run). 