### PR TITLE
Remove noindex meta tags.

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,8 +8,6 @@ site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="googlebot" content="noindex, nofollow">
-  <meta name="bingbot" content="noindex, nofollow">
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
Closes #310.

This should not be merged without explicit sign-off to allow indexing by search engines (Google and Bing). 

**Do not merge** for soft-launch. 