### PR TITLE
Change homepage link to travel category landing

### DIFF
--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -31,7 +31,7 @@ top_questions:
     link: "/keeping-home-safe/#what-steps-can-my-family-take-to-reduce-our-risk-of-getting-covid-19"
     question: How do I reduce my risk?
   - icon: plane
-    link: /travel/#should-i-travel-within-the-united-states
+    link: /travel
     question: Can I travel?
 questions_box_1:
   questions:


### PR DESCRIPTION
Changes homepage link for "Can I travel?" from focus on traveling in the U.S. to travel category with all questions.