### PR TITLE
Conditionally render page description

### DIFF
--- a/_includes/meta-description.html
+++ b/_includes/meta-description.html
@@ -1,5 +1,10 @@
 {%- if page.layout == 'post' -%}
-    {{ page.content | strip_html | split: '.' | first | strip_newlines | truncate: 156 }}
+    {% assign description = page.content | strip_html | split: '.' | first | truncate: 156 %}
+        {%- if description.size < 50 -%}
+            {{ page.content | strip_html | truncate: 156 }}
+        {%- else -%}
+            {{ description }}
+        {%- endif -%}
 {%- elsif page.layout == 'category' -%}
     Questions and answers about {{page.title}}
 {%- else -%}


### PR DESCRIPTION
Closes #334 

For each page, if the first sentence is less than 50 characters render the first 156 characters of content as the description.


Example (/parents-and-children/should-children-wear-face-masks/):
```html
<meta name="description" content="No. If your child is healthy, there is no need for them to wear a facemask. Only people who have symptoms of illness or who are providing care to those w...">
```
If the first sentence is 50 or more characters, use that as the description.
Example (/k12-childcare/should-my-school-screen-students-for-cases-of-covid-19/):
```html
<meta name="description" content="Schools and childcare programs are not expected to screen children, students, or staff to identify cases of COVID-19">
```