### PR TITLE
Convert social media previews to full URLs.

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -24,7 +24,7 @@ site, this is the place to do it.
   <meta name="twitter:site" content="@{{site.twitter}}" />
   <meta name="twitter:title" content="{% include title.html %}" />
   <meta name="twitter:description" content="{% include meta-description.html %}" />
-  <meta name="twitter:image" content="{% asset social-media-preview.png @path %}" />
+  <meta name="twitter:image" content="{{ site.url }}{% asset social-media-preview.png @path %}" />
 
   <meta name="baseurl" content="{{site.baseurl}}">
   <meta name="searchgov_endpoint" content="{{site.searchgov.endpoint}}">
@@ -32,7 +32,7 @@ site, this is the place to do it.
   <meta name="searchgov_access_key" content="{{site.searchgov.access_key}}">
 
   <meta property="og:type" content="article">
-  <meta property="og:image" content="{% asset social-media-preview.png @path %}">
+  <meta property="og:image" content="{{ site.url }}{% asset social-media-preview.png @path %}">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="800">
   <meta property="og:image:alt" content="Coronavirus FAQ">


### PR DESCRIPTION
Closes #364.

Twitter seems to require these to be absolute URLs to function. Opening this PR for documentation purposes.