### PR TITLE
Add note on Federalist cache.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ We use the `demo` (staging) and `master` branches for our pre-production and pro
 - The dev team member merges the pull request, and ensures the Federalist deployment to the production environment completes successfully.
 
   - The dev team member confirms the changeset at [faq.coronavirus.gov](https://faq.coronavirus.gov/).
+  
+  - Changes may take up to 60 seconds to be visible in production due to caching in Federalist (Cloudfront).
 
 A few additional notes:
 


### PR DESCRIPTION
Adding a note to indicate that production changes may take 60 seconds to be visible — realized this was something I knew today but wasn’t yet documented. 

I don’t believe we can link out to the configuration setting for this, since I believe it’s a private config setting in Federalist. 