### PR TITLE
Removed to CDC-specific sr reference

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,10 +1,22 @@
-<form id="search_form" action="{{ site.baseurl }}/search/" class="usa-search {{ include.extra_class}}">
+<form
+  id="search_form"
+  action="{{ site.baseurl }}/search/"
+  class="usa-search {{ include.extra_class}}"
+>
   <div role="search" class="grid-row">
     <div class="grid-col">
-      <label class="usa-label usa-sr-only" for="search-box">Search CDC for information on COVID-19</label>
+      <label class="usa-label usa-sr-only" for="search-box"
+        >Search for information on COVID-19</label
+      >
       <div class="autocomplete_container">
-        <input class="usa-input height-full" id="search-box" autocomplete="off" name="query" type="search"
-          placeholder="{{ include.placeholder }}" />
+        <input
+          class="usa-input height-full"
+          id="search-box"
+          autocomplete="off"
+          name="query"
+          type="search"
+          placeholder="{{ include.placeholder }}"
+        />
       </div>
     </div>
     <div class="grid-col-auto">


### PR DESCRIPTION
- Removed explict reference to CDC in .usa-sr-only label
- Searched code (!_content) for references to CDC, which yielded expected explicit references to CDC in footer, header, etc. 

Note: I do see references to CDC as the owner for many categories in the category file. It looks like other categories have other agencies as owners so I believe this is expected as we have expanded content. 

Resolves #348 