### PR TITLE
Include FQDN in canonical URLs, show full page URL.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ require_relative './htmlproofer/target_blank_checks.rb'
 desc 'Run HTMLProofer w/ custom plugins'
 task :htmlproof do
 
-  HTMLProofer.check_directory("./_site",
-                              {:empty_alt_ignore => true}).run
+  HTMLProofer.check_directory("./_site", {
+    empty_alt_ignore: true,
+    url_swap: {
+      # treat urls to faq.coronavirus.gov as local
+      'https://faq.coronavirus.gov' => ''
+    }
+  }).run
 end

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -36,8 +36,8 @@ site, this is the place to do it.
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="800">
   <meta property="og:image:alt" content="Coronavirus FAQ">
-  <link rel="canonical" href="{{site.baseurl}}/">
-  <meta property="og:url" content="{{site.baseurl}}/">
+  <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
+  <meta property="og:url" content="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" rel="stylesheet">
   <!-- Favicons
     ================================================== -->


### PR DESCRIPTION
Fixes #430.

The canonical URL should be the clean path to the current page, including the hostname. This PR implements that fix.

Additionally, since these are now URLs which point to production, HTMLProofer tries to check to see if these URLs are broken, which causes all new pages to fail builds. Fixed this issue by treating any URL to `https://faq.coronavirus.gov` as local in the HTMLProofer configuration.