### PR TITLE
Update CDC children, facemasks to source

### DIFF
--- a/_content/parents-and-children/should-children-wear-face-masks.md
+++ b/_content/parents-and-children/should-children-wear-face-masks.md
@@ -2,7 +2,7 @@
 title: Should children wear facemasks?
 category: parents-and-children
 layout: post
-date: April 3, 2020
+date: April 11, 2020
 source: CDC
 promoted: false
 source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747


### PR DESCRIPTION
Fixes #491 

Our site tracker identified a change to CDC facemask guidance.

##Should children wear facemasks?
### Current
CDC recommends that people wear a cloth face covering their nose and mouth in the community setting during the COVID-19 pandemic, however, children younger than 2 years of age are listed as an exception. Children younger than 2 years should not wear a cloth face covering because of concerns that they might suffocate.

### Updated
CDC recommends that everyone 2 years and older wear a cloth face covering that covers their nose and mouth when they are out in the community. Cloth face coverings should NOT be put on babies or children younger than 2 because of the danger of suffocation. Children younger than 2 years of age are listed as an exception as well as anyone who has trouble breathing or is unconscious, incapacitated, or otherwise unable to remove the face covering without assistance.

Wearing cloth face coverings is a public health measure people should take to reduce the spread of COVID-19 in addition to (not instead of) social distancing, frequent hand cleaning, and other everyday preventive actions. A cloth face covering is not intended to protect the wearer but may prevent the spread of virus from the wearer to others. This would be especially important if someone is infected but does not have symptoms. Medical face masks and N95 respirators are still reserved for healthcare personnel and other first responders, as recommended by current CDC guidance.