### PR TITLE
Always run both test commands in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,39 @@ jobs:
           key: v2-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: npm run test
+      - run: npm run build
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - node_modules
+            - vendor/bundle
+            - _site
 
+  test-htmlproofer:
+    docker:
+      - image: circleci/ruby:2.6.3-node-browsers-legacy
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run: bundle config --local path vendor/bundle
+      - run: npm run test:htmlproofer
+
+  test-jest:
+    docker:
+      - image: circleci/ruby:2.6.3-node-browsers-legacy
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run: npm run test:jest
 
 workflows:
   version: 2
   commit:
     jobs:
       - build
+      - test-htmlproofer:
+          requires: [build]
+      - test-jest:
+          requires: [build]


### PR DESCRIPTION
If HTMLProofer fails, we still want to see the results of jest. 

This is especially poignant if we temporarily have a broken link — we want to make sure we’re not introducing further issues, which could sneak in and hide behind the broken link failure. 

The configuration in this PR results in running the tests commands in parallel, and will report both their statuses (as well as the build status — if the site could be built) to GitHub: 

![image](https://user-images.githubusercontent.com/14930/79148464-7ed87180-7d93-11ea-8ef2-2d0eb41425f1.png)

