### PR TITLE
Replaces travel advisory alert banner

### DIFF
--- a/_categories/travel.md
+++ b/_categories/travel.md
@@ -6,6 +6,6 @@ owner: CDC
 homepage_order: 3
 banner:
   display: true
-  heading: "CDC issues Domestic Travel Advisory for New York, New Jersey, and Connecticut."
-  content: "The CDC urges residents of New York, New Jersey, and Connecticut to refrain from non-essential domestic travel for 14 days effective immediately. This Domestic Travel Advisory does not apply to employees of critical infrastructure industries, including but not limited to trucking, public health professionals, financial services, and food supply. These employees of critical infrastructure, as <a href='https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce'>defined by the Department of Homeland Security</a>, have a special responsibility to maintain normal work schedule. The Governors of New York, New Jersey, and Connecticut will have full discretion to implement this Domestic Travel Advisory."
+  heading: "State or local governments may have issued orders or provided additional guidance."
+  content: "Check <a href='https://www.cdc.gov/publichealthgateway/healthdirectories/healthdepartments.html'>public health departments</a> for detailed information."
 ---


### PR DESCRIPTION
- Replaces travel advisory alert banner to match CDC
- Wording isn't ideal; perhaps we can request edits