### PR TITLE
Allow multiple sources for content

### DIFF
--- a/_agencies/cdc.md
+++ b/_agencies/cdc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: CDC
+name: cdc
 title: "CDC"
 sitemap: false
 ---

--- a/_agencies/dhs.md
+++ b/_agencies/dhs.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: DHS
+name: dhs
 title: "DHS"
 sitemap: false
 ---

--- a/_agencies/fcc.md
+++ b/_agencies/fcc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: FCC
+name: fcc
 title: "FCC"
 sitemap: false
 ---

--- a/_agencies/fema.md
+++ b/_agencies/fema.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: FEMA
+name: fema
 title: "FEMA"
 sitemap: false
 ---

--- a/_agencies/ftc.md
+++ b/_agencies/ftc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: irs
-title: "IRS"
+name: ftc
+title: "FTC"
 sitemap: false
 ---

--- a/_agencies/sba.md
+++ b/_agencies/sba.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: Small Business Administration
+name: sba
 permalink: /agency/sba/
 title: "Small Business Administration"
 sitemap: false

--- a/_agencies/treasury.md
+++ b/_agencies/treasury.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
-name: Treasury
+name: treasury
 title: "Treasury"
 sitemap: false
 ---

--- a/_content/animals/are-pets-from-a-shelter-safe.md
+++ b/_content/animals/are-pets-from-a-shelter-safe.md
@@ -1,12 +1,13 @@
 ---
-title: Are pets from a shelter safe to adopt?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Are pets from a shelter safe to adopt?
 ---
 
 There is no reason to think that any animals, including shelter pets, in the United States might be a source of COVID-19.

--- a/_content/animals/can-animals-carry-the-virus.md
+++ b/_content/animals/can-animals-carry-the-virus.md
@@ -1,12 +1,13 @@
 ---
-title: Can animals carry the virus that causes COVID-19 on their skin or fur?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Can animals carry the virus that causes COVID-19 on their skin or fur?
 ---
 
 At this time, there is no evidence that the virus that causes COVID-19 can spread to people from the skin or fur of pets.

--- a/_content/animals/can-i-get-covid-19-from-my-pets.md
+++ b/_content/animals/can-i-get-covid-19-from-my-pets.md
@@ -1,12 +1,13 @@
 ---
-title: Can I get COVID-19 from my pets or other animals?
 category: animals
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Can I get COVID-19 from my pets or other animals?
 ---
 
 At this time, there is no evidence that companion animals, including pets, can spread COVID-19 to people or that they might be a source of infection in the United States. To date, CDC has not received any reports of pets becoming sick with COVID-19 in the United States.

--- a/_content/animals/can-i-travel-to-the-us-with-dogs.md
+++ b/_content/animals/can-i-travel-to-the-us-with-dogs.md
@@ -1,13 +1,13 @@
 ---
-title: Can I travel with or import dogs to the United States during the outbreak?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Can I travel with or import dogs to the United States during the outbreak?
 ---
 
 Please refer to [CDC’s requirements for bringing a dog to the United States](https://www.cdc.gov/importation/bringing-an-animal-into-the-united-states/index.html). The current [requirements for rabies vaccination](https://www.cdc.gov/importation/bringing-an-animal-into-the-united-states/rabies-vaccine.html) apply to dogs imported from China, a high-risk country for rabies.
-

--- a/_content/animals/can-i-walk-my-dog.md
+++ b/_content/animals/can-i-walk-my-dog.md
@@ -1,12 +1,13 @@
 ---
-title: Can I walk my dog?
 category: animals
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
+title: Can I walk my dog?
 ---
 
 Walking a dog is important for both animal and human health and well-being. Walk dogs on a leash, maintaining at least 6 feet (2 meters) from other people and animals, do not gather in groups, and stay out of crowded places and avoid mass gatherings. Do not go to dog parks or public places where a large number of people and dogs gather. To help maintain social distancing, do not let other people pet your dog when you are out for a walk.

--- a/_content/animals/do-i-need-to-get-my-pet-tested.md
+++ b/_content/animals/do-i-need-to-get-my-pet-tested.md
@@ -1,12 +1,13 @@
 ---
-title: Do I need to get my pet tested for COVID-19?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Do I need to get my pet tested for COVID-19?
 ---
 
 No. At this time, routine testing of animals for COVID-19 is not recommended.

--- a/_content/animals/should-avoid-contact-with-pets.md
+++ b/_content/animals/should-avoid-contact-with-pets.md
@@ -1,12 +1,13 @@
 ---
-title: Should I avoid contact with pets or other animals if I am sick with COVID-19?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Should I avoid contact with pets or other animals if I am sick with COVID-19?
 ---
 
 You should restrict contact with pets and other animals while you are sick with COVID-19, just like you would around other people. Although there have not been reports of pets or other animals becoming sick with COVID-19, it is still recommended that people sick with COVID-19 limit contact with animals until more information is known about the new coronavirus. When possible, have another member of your household care for your animals while you are sick. If you are sick with COVID-19, avoid contact with your pet, including petting, snuggling, being kissed or licked, and sharing food. If you must care for your pet or be around animals while you are sick, wash your hands before and after you interact with pets.

--- a/_content/animals/since-tigers-can-get-infected-should-i-worry-about-my-pet-cat.md
+++ b/_content/animals/since-tigers-can-get-infected-should-i-worry-about-my-pet-cat.md
@@ -1,12 +1,14 @@
 ---
-title: Since tigers can get infected with the virus that causes COVID-19, should I worry about my pet cat?
 category: animals
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
+title: Since tigers can get infected with the virus that causes COVID-19, should I
+  worry about my pet cat?
 ---
 
 The tiger infected with the virus that causes COVID-19 is the first case of its kind. We are still learning about this virus and how it spreads, but it appears it can spread from humans to animals in some situations. CDC is aware of a very small number of pets outside the United States, including cats, reported to be infected with the virus that causes COVID-19 after close contact with people with COVID-19.

--- a/_content/animals/what-about-imported-animals-or-animal-products.md
+++ b/_content/animals/what-about-imported-animals-or-animal-products.md
@@ -1,12 +1,13 @@
 ---
-title: Should I be concerned about imported animals or animal products?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: Should I be concerned about imported animals or animal products?
 ---
 
 CDC does not have any evidence to suggest that imported animals or animal products pose a risk for spreading COVID-19 in the United States. This is a rapidly evolving situation and information will be updated as it becomes available. The U.S. Centers for Disease Control and Prevention (CDC), the U. S. Department of Agriculture (USDA), and the U.S. Fish and Wildlife Service (FWS) play distinct but complementary roles in regulating the importation of live animals and animal products into the United States. [CDC regulates](https://www.cdc.gov/importation/index.html) animals and animal products that pose a threat to human health, [USDA regulates](https://www.aphis.usda.gov/aphis/ourfocus/animalhealth/animal-and-animal-product-import-information) animals and animal products that pose a threat to agriculture; and [FWS regulates](https://www.fws.gov/le/businesses.html) importation of endangered species and wildlife that can harm the health and welfare of humans, the interests of agriculture, horticulture, or forestry, and the welfare and survival of wildlife resources.

--- a/_content/animals/what-animals-can-get-covid-19.md
+++ b/_content/animals/what-animals-can-get-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: What animals can get COVID-19?
 category: animals
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
+title: What animals can get COVID-19?
 ---
 
 We don’t know for sure which animals can be infected with the virus that causes COVID-19. CDC is aware of a very small number of pets, including dogs and cats, outside the United States reported to be infected with the virus that causes COVID-19 after close contact with people with COVID-19. A tiger at a zoo in New York has also tested positive for the virus.

--- a/_content/animals/what-precautions-with-imported-animals.md
+++ b/_content/animals/what-precautions-with-imported-animals.md
@@ -1,12 +1,14 @@
 ---
-title: What precautions should be taken for animals that have recently been imported (for example, by shelters, rescue groups, or as personal pets) from China?
 category: animals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390773118
+title: What precautions should be taken for animals that have recently been imported
+  (for example, by shelters, rescue groups, or as personal pets) from China?
 ---
 
 Imported animals will need to meet [CDC](https://www.cdc.gov/importation/bringing-an-animal-into-the-united-states/index.html) and [USDA](https://www.aphis.usda.gov/aphis/ourfocus/importexport/animal-import-and-export) requirements for entering the United States. At this time, there is no evidence that companion animals, including pets and service animals, can spread COVID-19. As with any animal introduced to a new environment, animals recently imported should be observed daily for signs of illness. If an animal becomes ill, the animal should be examined by a veterinarian. Call your local veterinary clinic before bringing the animal into the clinic and let them know that the animal was recently imported from another country.

--- a/_content/animals/what-should-i-do-if-my-pet-gets-sick.md
+++ b/_content/animals/what-should-i-do-if-my-pet-gets-sick.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do if my pet gets sick and I think it’s COVID-19?
 category: animals
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
+title: What should I do if my pet gets sick and I think it’s COVID-19?
 ---
 
 There is a very small number of animals around the world reported to be infected with the virus that causes COVID-19 after having contact with a person with a COVID-19 infection. Talk to your veterinarian about any health concerns you have about your pets.

--- a/_content/animals/why-are-animals-being-tested-when-people-cant.md
+++ b/_content/animals/why-are-animals-being-tested-when-people-cant.md
@@ -1,12 +1,13 @@
 ---
-title: Why are animals being tested when many people can’t get tested?
 category: animals
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
 excerpt: COVID-19 and animals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#COVID-19-and-Animals
+title: Why are animals being tested when many people can’t get tested?
 ---
 
 Animals are only being tested in very rare circumstances. Routine testing of animals is not recommended at this time, and any tests done on animals are done on a case by case basis. For example, if the pet of a COVID-19 patient has a new, concerning illness with symptoms similar to those of COVID-19, the animal’s veterinarian might consult with public health and animal health officials to determine if testing is needed.

--- a/_content/basics/how-can-people-help-stop-stigma-related-to-COVID-19.md
+++ b/_content/basics/how-can-people-help-stop-stigma-related-to-COVID-19.md
@@ -1,12 +1,13 @@
 ---
-title: How can people help stop stigma related to COVID-19?
 category: basics
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
 excerpt: About COVID-19
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
+title: How can people help stop stigma related to COVID-19?
 ---
 
 People can fight stigma and help, not hurt, others by providing social support. Counter stigma by learning and sharing facts. Communicating the facts that viruses do not target specific racial or ethnic groups and how COVID-19 actually spreads can help stop stigma.

--- a/_content/basics/how-does-cdc-covid19-case-numbers-compare-with-who.md
+++ b/_content/basics/how-does-cdc-covid19-case-numbers-compare-with-who.md
@@ -1,12 +1,14 @@
 ---
-title: How do CDC's COVID-19 case numbers compare with those provided by World Health Organization (WHO) or John Hopkins?
 category: basics
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
 excerpt: About COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
+title: How do CDC's COVID-19 case numbers compare with those provided by World Health
+  Organization (WHO) or John Hopkins?
 ---
 
 CDC’s COVID-19 case numbers include many publicly reported numbers, including information from state, local, territorial, international and external partners.

--- a/_content/basics/is-there-a-list-of-essential-industries.md
+++ b/_content/basics/is-there-a-list-of-essential-industries.md
@@ -1,12 +1,13 @@
 ---
-title: Is there a list of essential industries and employees?
 category: basics
-layout: post
 date: March 29, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce
+title: Is there a list of essential industries and employees?
 ---
 
 Yes. The Cybersecurity and Infrastructure Security Agency (CISA) has a list of essential industries available online.

--- a/_content/basics/states-covid19-cases-numbers-differ-from-CDC-website.md
+++ b/_content/basics/states-covid19-cases-numbers-differ-from-CDC-website.md
@@ -1,12 +1,14 @@
 ---
-title: Why do some state's COVID-19 cases numbers sometimes differ from what is posted on CDC's website?
 category: basics
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
 excerpt: About COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
+title: Why do some state's COVID-19 cases numbers sometimes differ from what is posted
+  on CDC's website?
 ---
 
 CDC’s overall case numbers are validated through a confirmation process with jurisdictions. The process used for finding and confirming cases displayed by different places may differ.

--- a/_content/basics/what-are-essential-industries.md
+++ b/_content/basics/what-are-essential-industries.md
@@ -1,12 +1,13 @@
 ---
-title: What are essential employees and industries? 
 category: basics
-layout: post
 date: March 29, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce
+title: What are essential employees and industries?
 ---
 
 The Cybersecurity and Infrastructure Security Agency (CISA) executes the Secretary of Homeland Security’s responsibilities as assigned under the Homeland Security Act of 2002 to provide strategic guidance, promote a national unity of effort, and coordinate the overall federal effort to ensure the security and resilience of the Nation's critical infrastructure.

--- a/_content/basics/what-is-a-novel-coronavirus.md
+++ b/_content/basics/what-is-a-novel-coronavirus.md
@@ -1,12 +1,13 @@
 ---
-title: What is a novel coronavirus?
 category: basics
+date: April 13, 2020
+excerpt: About COVID-19
 layout: post
 promoted: true
-date: April 13, 2020
-source: CDC
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
-excerpt: About COVID-19
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
+title: What is a novel coronavirus?
 ---
 
 A novel coronavirus is a new coronavirus that has not been previously identified. The virus causing coronavirus disease 2019 (COVID-19), is not the same as the [coronaviruses that commonly circulate among humans](https://www.cdc.gov/coronavirus/types.html) and cause mild illness, like the common cold.

--- a/_content/basics/why-do-case-numbers-from-previous-day-increase.md
+++ b/_content/basics/why-do-case-numbers-from-previous-day-increase.md
@@ -1,12 +1,13 @@
 ---
-title: Why do the number of cases for previous days increase?
 category: basics
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
 excerpt: About COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#covid19-basics
+title: Why do the number of cases for previous days increase?
 ---
 
 Delays in reporting can cause the number of COVID-19 cases reported on previous days to increase. (Sometimes this effect is described as “backfill.”) State, local, and territorial health departments report the number of cases that have been confirmed and share these data with CDC. Since it takes time to conduct laboratory testing, cases from a previous day may be added to the daily counts a few days late.

--- a/_content/basics/why-is-the-disease-called-covid-19.md
+++ b/_content/basics/why-is-the-disease-called-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Why is the disease called COVID-19?
 category: basics
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
 excerpt: About COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
+title: Why is the disease called COVID-19?
 ---
 
 On February 11, 2020 the World Health Organization [announced](https://twitter.com/DrTedros/status/1227297754499764230) an official name for the disease that is causing the 2019 novel coronavirus outbreak, first identified in Wuhan China. The new name of this disease is coronavirus disease 2019, abbreviated as COVID-19. In COVID-19, ‘CO’ stands for ‘corona,’ ‘VI’ for ‘virus,’ and ‘D’ for disease. Formerly, this disease was referred to as “2019 novel coronavirus” or “2019-nCoV”.

--- a/_content/basics/why-might-someone-create-stigma.md
+++ b/_content/basics/why-might-someone-create-stigma.md
@@ -1,12 +1,14 @@
 ---
-title: Why might someone blame or avoid individuals and groups (create stigma) because of COVID-19?
 category: basics
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
 excerpt: About COVID-19
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386215012
+title: Why might someone blame or avoid individuals and groups (create stigma) because
+  of COVID-19?
 ---
 
 People in the U.S. may be worried or anxious about friends and relatives who are living in or visiting areas where COVID-19 is spreading. Some people are worried about getting the disease from these people. Fear and anxiety can lead to social stigma, for example, toward people who live in certain parts of the world, people who have traveled internationally, people who were in quarantine, or healthcare professionals.

--- a/_content/community-events/do-i-need-to-cancel-if-there-are-confirmed-covid19-cases.md
+++ b/_content/community-events/do-i-need-to-cancel-if-there-are-confirmed-covid19-cases.md
@@ -1,12 +1,14 @@
 ---
-title: Do I need to cancel an event if there are confirmed cases of COVID-19 in the community?
 category: community-events
-layout: post
 date: March 29, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: Do I need to cancel an event if there are confirmed cases of COVID-19 in the
+  community?
 ---
 
 If there is minimal or moderate spread of COVID-19 in the community, CDC recommends cancelling an:

--- a/_content/community-events/information-that-i-can-share-with-attendees-about-COVID-19.md
+++ b/_content/community-events/information-that-i-can-share-with-attendees-about-COVID-19.md
@@ -1,12 +1,13 @@
 ---
-title: Is there information that I can share with staff and attendees about COVID-19?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: Is there information that I can share with staff and attendees about COVID-19?
 ---
 
 Share these resources to help people understand COVID-19 and steps they can take to help protect themselves:

--- a/_content/community-events/steps-to-take-if-attendee-or-event-staff-develops-COVID-19.md
+++ b/_content/community-events/steps-to-take-if-attendee-or-event-staff-develops-COVID-19.md
@@ -1,12 +1,14 @@
 ---
-title: What steps should I take if an attendee or staff person develops symptoms of COVID-19 while at my event?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: What steps should I take if an attendee or staff person develops symptoms of
+  COVID-19 while at my event?
 ---
 
 If a staff member or attendee becomes sick at your event, separate them from others as soon as possible and until they can go home. Provide them with clean, <a href="https://www.cdc.gov/niosh/npptl/pdfs/UnderstandDifferenceInfographic-508.pdf"> disposable facemasks</a> to wear, if available. If not available, provide them with a tissue or some other way to cover their coughs and sneezes. If needed, contact emergency services for those who need emergency care. Public transportation, shared rides, and taxis should be avoided for sick persons. 

--- a/_content/community-events/things-to-consider-when-deciding-to-postpone-or-cancel-events.md
+++ b/_content/community-events/things-to-consider-when-deciding-to-postpone-or-cancel-events.md
@@ -1,12 +1,13 @@
 ---
-title: What should I consider when deciding to postpone or cancel an event? 
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: What should I consider when deciding to postpone or cancel an event?
 ---
 
 Consult with local public health officials and keep asking yourself, based on current conditions, whether to postpone, cancel, or significantly reduce the number of attendees (if possible) at an event or gathering. When determining if you should postpone or cancel a large gathering or event, consider the:

--- a/_content/community-events/what-actions-staff-and-attendees-can-take-to-prevent-COVID-19.md
+++ b/_content/community-events/what-actions-staff-and-attendees-can-take-to-prevent-COVID-19.md
@@ -1,12 +1,13 @@
 ---
-title: What actions can staff and attendees take to prevent the spread of COVID-19?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: What actions can staff and attendees take to prevent the spread of COVID-19?
 ---
 
 Encourage staff and attendees to take <a href="https://www.cdc.gov/coronavirus/2019-ncov/about/prevention-treatment.html"> everyday preventive actions</a> to help prevent the spread of respiratory illnesses such as COVID-19. This includes:

--- a/_content/community-events/what-actions-to-take-to-plan-for-outbreak.md
+++ b/_content/community-events/what-actions-to-take-to-plan-for-outbreak.md
@@ -1,12 +1,13 @@
 ---
-title: What actions should I take to plan for an outbreak?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: What actions should I take to plan for an outbreak?
 ---
 
 Creating an emergency plan for mass gatherings and large community events, such as concerts and sporting events, can help protect the health of your staff, attendees, and the local community. This planning should include:

--- a/_content/community-events/what-is-the-best-way-to-clean-event-space-after-confirmed-case-of-COVID-19-at-an-event.md
+++ b/_content/community-events/what-is-the-best-way-to-clean-event-space-after-confirmed-case-of-COVID-19-at-an-event.md
@@ -1,12 +1,14 @@
 ---
-title: What is the best way to clean and disinfect the event space after a confirmed case of COVID-19 at my event?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: What is the best way to clean and disinfect the event space after a confirmed
+  case of COVID-19 at my event?
 ---
 
 CDC has guidance for cleaning and disinfecting rooms and areas where a person with suspected or confirmed COVID-19 has visited. See <a href="https://www.cdc.gov/coronavirus/2019-ncov/community/organizations/cleaning-disinfection.html"> Environmental Cleaning and Disinfection Recommendations</a>.

--- a/_content/community-events/when-does-the-cdc-recommend-I-cancel-or-postpone-events.md
+++ b/_content/community-events/when-does-the-cdc-recommend-I-cancel-or-postpone-events.md
@@ -1,12 +1,13 @@
 ---
-title: When does the CDC recommend that I cancel or postpone an event?
 category: community-events
-layout: post
 date: March 15, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
 excerpt: Community events
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/event-planners-and-attendees-faq.html
+title: When does the CDC recommend that I cancel or postpone an event?
 ---
 
 If there is minimal or moderate spread of COVID-19 in the community, CDC recommends cancelling an:

--- a/_content/financial-help/how-can-i-file-the-tax-return-needed-to-receive-payment.md
+++ b/_content/financial-help/how-can-i-file-the-tax-return-needed-to-receive-payment.md
@@ -1,12 +1,13 @@
 ---
-title: How can I file the tax return needed to receive my economic impact payment?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: How can I file the tax return needed to receive my economic impact payment?
 ---
 
 [IRS.gov/coronavirus](https://www.irs.gov/coronavirus) will soon provide information instructing people in these groups on how to file a 2019 tax return with simple, but necessary, information including their filing status, number of dependents and direct deposit bank account information.

--- a/_content/financial-help/how-do-i-submit-banking-information.md
+++ b/_content/financial-help/how-do-i-submit-banking-information.md
@@ -1,12 +1,14 @@
 ---
-title: If I did not file a tax return in 2018 or 2019, how do I send the IRS my banking information so I can receive an Economic Impact Payment?
 category: financial-help
-layout: post
 date: April 10, 2020
-source: IRS
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: irs
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: If I did not file a tax return in 2018 or 2019, how do I send the IRS my banking
+  information so I can receive an Economic Impact Payment?
 ---
 
 You can submit your information to the IRS through a [secure web portal](https://www.irs.gov/coronavirus/non-filers-enter-payment-info-here) on IRS.gov. You will need to provide your full name, date of birth, social security number, and bank account information to use this system. After you submit your information, you will receive your Economic Impact Payment through direct deposit.

--- a/_content/financial-help/how-will-the-irs-know-where-to-send.md
+++ b/_content/financial-help/how-will-the-irs-know-where-to-send.md
@@ -1,12 +1,13 @@
 ---
-title: How will the IRS know where to send my payment?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: How will the IRS know where to send my payment?
 ---
 
 The vast majority of people do not need to take any action. The IRS will calculate and automatically send the economic impact payment to those eligible.

--- a/_content/financial-help/i-am-not-typically-required-to-file-a-tax-return.md
+++ b/_content/financial-help/i-am-not-typically-required-to-file-a-tax-return.md
@@ -1,12 +1,13 @@
 ---
-title: I am not typically required to file a tax return. Can I still receive my payment?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: I am not typically required to file a tax return. Can I still receive my payment?
 ---
 
 Yes. People who typically do not file a tax return will need to file a simple tax return to receive an economic impact payment. Low-income taxpayers, senior citizens, Social Security recipients, some veterans and individuals with disabilities who are otherwise not required to file a tax return will not owe tax.

--- a/_content/financial-help/i-have-not-filed-my-tax-return-for-2018-or-2019.md
+++ b/_content/financial-help/i-have-not-filed-my-tax-return-for-2018-or-2019.md
@@ -1,12 +1,14 @@
 ---
-title: I have not filed my tax return for 2018 or 2019. Can I still receive an economic impact payment?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: I have not filed my tax return for 2018 or 2019. Can I still receive an economic
+  impact payment?
 ---
 
 Yes. The IRS urges anyone with a tax filing obligation who has not yet filed a tax return for 2018 or 2019 to file as soon as they can to receive an economic impact payment. Taxpayers should include direct deposit banking information on the return.

--- a/_content/financial-help/i-need-to-file-a-tax-return.md
+++ b/_content/financial-help/i-need-to-file-a-tax-return.md
@@ -1,12 +1,13 @@
 ---
-title: I need to file a tax return. How long are the economic impact payments available?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: I need to file a tax return. How long are the economic impact payments available?
 ---
 
 For those concerned about visiting a tax professional or local community organization in person to get help with a tax return, these economic impact payments will be available throughout the rest of 2020.

--- a/_content/financial-help/if-i-receive-social-security-benefits.md
+++ b/_content/financial-help/if-i-receive-social-security-benefits.md
@@ -1,12 +1,14 @@
 ---
-title: If I receive Social Security benefits, do I need to file a tax return to receive my Economic Impact Payment?
 category: financial-help
-layout: post
 date: April 1, 2020
-source: Treasury
+excerpt: 'Employee Retention Tax Credit: What You Need to Know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm967
-excerpt: "Employee Retention Tax Credit: What You Need to Know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm967
+title: If I receive Social Security benefits, do I need to file a tax return to receive
+  my Economic Impact Payment?
 ---
 
 The Department of the Treasury and the IRS announced that Social Security beneficiaries who are not typically required to file tax returns will not need to file an abbreviated tax return to receive an Economic Impact Payment. Instead, payments will be automatically deposited into their bank accounts. Recipients will receive these payments as a direct deposit or by paper check, just as they would normally receive their benefits.

--- a/_content/financial-help/is-the-government-delaying-tax-day.md
+++ b/_content/financial-help/is-the-government-delaying-tax-day.md
@@ -1,14 +1,15 @@
 ---
-title: Is the government delaying Tax Day?
 category: financial-help
-layout: post
 date: March 31, 2020
-source: Treasury
-source_url: https://home.treasury.gov/news/press-releases/sm953
-source_2: IRS
-source_url_2: https://www.irs.gov/coronavirus
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: true
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm953
+- agency: irs
+  url: https://www.irs.gov/coronavirus
+title: Is the government delaying Tax Day?
 ---
 
 The Treasury Department and the IRS has delayed Tax Day from April 15 to July 15. This means you will not be required to file your federal income tax until July 15, 2020. You are not required to fill out any paperwork or notify the government to take advantage of this extra time. This delay **only** applies to **federal income tax**, not state taxes or other federal taxes. For more information, please view the [official IRS guidance (PDF)](https://www.irs.gov/pub/irs-drop/n-20-18.pdf).

--- a/_content/financial-help/the-irs-does-not-have-my-direct-deposit-information.md
+++ b/_content/financial-help/the-irs-does-not-have-my-direct-deposit-information.md
@@ -1,12 +1,13 @@
 ---
-title: The IRS does not have my direct deposit information. What can I do?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: The IRS does not have my direct deposit information. What can I do?
 ---
 
 In the coming weeks, Treasury plans to develop a web-based portal for individuals to provide their banking information to the IRS online, so that individuals can receive payments immediately as opposed to checks in the mail.

--- a/_content/financial-help/what-if-i-cant-complete-my-taxes-by-april-15.md
+++ b/_content/financial-help/what-if-i-cant-complete-my-taxes-by-april-15.md
@@ -1,12 +1,13 @@
 ---
-title: What if I can't complete my taxes by April 15?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm953
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm953
+title: What if I can't complete my taxes by April 15?
 ---
 
 Tax filings and payments for all federal income taxes (including self-employment tax) due on April 15, 2020, regardless of amount, will now be due on July 15, 2020. 

--- a/_content/financial-help/what-should-i-do-if-i-receive-calls-claiming-to-be-from-the-treasury-department.md
+++ b/_content/financial-help/what-should-i-do-if-i-receive-calls-claiming-to-be-from-the-treasury-department.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do if I receive calls claiming to be from the Treasury Department?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/cares
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/cares
+title: What should I do if I receive calls claiming to be from the Treasury Department?
 ---
 
 If you receive calls, emails, or other communications claiming to be from the Treasury Department and offering COVID-19 related grants or stimulus payments in exchange for personal financial information, or an advance fee, or charge of any kind, including the purchase of gift cards, please do not respond. These are scams. Please [contact the FBI](https://www.fbi.gov/contact-us) so that the scammers can be tracked and stopped.

--- a/_content/financial-help/where-can-i-go-for-more-information.md
+++ b/_content/financial-help/where-can-i-go-for-more-information.md
@@ -1,12 +1,13 @@
 ---
-title: Where can I get more information about economic impact payments?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: Where can I get more information about economic impact payments?
 ---
 
 The IRS will post all key information on [IRS.gov/coronavirus](https://www.irs.gov/coronavirus) as soon as it becomes available.

--- a/_content/financial-help/who-is-eligible-for-payment.md
+++ b/_content/financial-help/who-is-eligible-for-payment.md
@@ -1,12 +1,13 @@
 ---
-title: Who is eligible for the economic impact payment?
 category: financial-help
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: true
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: Who is eligible for the economic impact payment?
 ---
 
 Tax filers with adjusted gross income up to $75,000 for individuals and up to $150,000 for married couples filing joint returns will receive the full payment. For filers with income above those amounts, the payment amount is reduced by $5 for each $100 above the $75,000/$150,000 thresholds. Single filers with income exceeding $99,000 and $198,000 for joint filers with no children are not eligible.

--- a/_content/financial-help/will-the-irs-call-or-email-me.md
+++ b/_content/financial-help/will-the-irs-call-or-email-me.md
@@ -1,12 +1,15 @@
 ---
-title: Will the IRS call or email me to get my bank information to receive my Economic Impact Payment?
 category: financial-help
-layout: post
 date: April 2, 2020
-source: IRS
+excerpt: IRS issues warning about Coronavirus-related scams; watch out for schemes
+  tied to economic impact payments
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/irs-issues-warning-about-coronavirus-related-scams-watch-out-for-schemes-tied-to-economic-impact-payments
-excerpt: "IRS issues warning about Coronavirus-related scams; watch out for schemes tied to economic impact payments"
+sources:
+- agency: irs
+  url: https://www.irs.gov/newsroom/irs-issues-warning-about-coronavirus-related-scams-watch-out-for-schemes-tied-to-economic-impact-payments
+title: Will the IRS call or email me to get my bank information to receive my Economic
+  Impact Payment?
 ---
 
 No, the IRS is not going to call or email you asking to verify or provide your financial information so you can get an Economic Impact Payment. You should also watch for text messages, websites, and social media attempts to get your money or personal information.

--- a/_content/funerals/am-i-at-risk-funeral.md
+++ b/_content/funerals/am-i-at-risk-funeral.md
@@ -1,12 +1,14 @@
 ---
-title: Am I at risk if I go to a funeral or visitation service for someone who died of COVID-19?
 category: funerals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
 excerpt: COVID-19 and funerals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
+title: Am I at risk if I go to a funeral or visitation service for someone who died
+  of COVID-19?
 ---
 
 There is currently no known risk associated with being in the same room at a funeral or visitation service with the body of someone who died of COVID-19.

--- a/_content/funerals/am-i-at-risk-touch-body.md
+++ b/_content/funerals/am-i-at-risk-touch-body.md
@@ -1,12 +1,13 @@
 ---
-title: Am I at risk if I touch the body of someone who died of COVID-19?
 category: funerals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
 excerpt: COVID-19 and funerals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
+title: Am I at risk if I touch the body of someone who died of COVID-19?
 ---
 
 COVID-19 is a new disease and **we are still learning how it spreads**. The virus that causes COVID-19 is thought to mainly spread from close contact (i.e., within about 6 feet) with a person who is currently sick with COVID-19. The virus likely spreads primarily through respiratory droplets produced when an infected person coughs or sneezes, similar to how influenza and other respiratory infections spread. These droplets can land in the mouths or noses of people who are nearby or possibly be inhaled into the lungs. This type of spread is not a concern after death.

--- a/_content/funerals/if-someone-dies-overseas.md
+++ b/_content/funerals/if-someone-dies-overseas.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do if a family member dies of COVID-19 while overseas?
 category: funerals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
 excerpt: COVID-19 and funerals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
+title: What should I do if a family member dies of COVID-19 while overseas?
 ---
 
 When a US citizen dies outside the United States, the deceased person’s next of kin or legal representative should notify US consular officials at the Department of State. Consular personnel are available 24 hours a day, 7 days a week, to provide assistance to US citizens for overseas emergencies. If a family member, domestic partner, or legal representative is in a different country from the deceased person, he or she should call the Department of State’s Office of Overseas Citizens Services in Washington, DC, from 8 am to 5 pm Eastern time, Monday through Friday, at 888-407-4747 (toll-free) or 202-501-4444. For emergency assistance after working hours or on weekends and holidays, call the Department of State switchboard at 202-647-4000 and ask to speak with the Overseas Citizens Services duty officer. In addition, the US embassy closest to or in the country where the US citizen died can provide assistance.

--- a/_content/funerals/what-do-funeral-home-workers-need-to-know.md
+++ b/_content/funerals/what-do-funeral-home-workers-need-to-know.md
@@ -1,12 +1,14 @@
 ---
-title: What do funeral home workers need to know about handling the bodies of people who die of COVID-19?
 category: funerals
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
 excerpt: COVID-19 and funerals
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584390222777
+title: What do funeral home workers need to know about handling the bodies of people
+  who die of COVID-19?
 ---
 
 A funeral or visitation service can be held for a person who has died of COVID-19. Funeral home workers should follow their routine infection prevention and control precautions when handling a decedent who died of COVID-19. If it is necessary to transfer a body to a bag, follow [Standard Precautions](https://www.cdc.gov/infectioncontrol/basics/standard-precautions.html), including additional personal protective equipment (PPE) if splashing of fluids is expected. For transporting a body after the body has been bagged, disinfect the outside of the bag with a product with [EPA-approved emerging viral pathogens claims](https://www.epa.gov/sites/production/files/2020-03/documents/sars-cov-2-list_03-03-2020.pdf) expected to be effective against COVID-19 based on data for harder to kill viruses. Follow the manufacturer’s instructions for all cleaning and disinfection products (e.g., concentration, application method and contact time, etc.). Wear disposable nitrile gloves when handling the body bag.

--- a/_content/k12-childcare/planning-and-preparedness/how-should-my-school-prepare-no-transmission.md
+++ b/_content/k12-childcare/planning-and-preparedness/how-should-my-school-prepare-no-transmission.md
@@ -1,12 +1,14 @@
 ---
-title: How should my school prepare when there is no community transmission in our area?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: How should my school prepare when there is no community transmission in our
+  area?
 ---
 
 The most important thing you can do now is to prepare. Schools need to be ready if COVID-19 does appear in their communities. Here are some strategies:

--- a/_content/k12-childcare/planning-and-preparedness/school-attended-before-diagnosed.md
+++ b/_content/k12-childcare/planning-and-preparedness/school-attended-before-diagnosed.md
@@ -1,12 +1,15 @@
 ---
-title: What should I do if the suspected sick student or staff member is confirmed to have COVID-19?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Responding to confirmed
+  COVID-19 cases'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Responding to confirmed COVID-19 cases"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should I do if the suspected sick student or staff member is confirmed
+  to have COVID-19?
 ---
 
 Immediately notify local health officials. These officials will help administrators determine a course of action for their childcare programs or schools.

--- a/_content/k12-childcare/planning-and-preparedness/school-prepare-minimal-moderate.md
+++ b/_content/k12-childcare/planning-and-preparedness/school-prepare-minimal-moderate.md
@@ -1,12 +1,14 @@
 ---
-title: How should my school prepare when there is minimal to moderate community transmission in our area?
 category: k12-childcare
-layout: post
 date: March 24, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: How should my school prepare when there is minimal to moderate community transmission
+  in our area?
 ---
 
 Work with your local health officials to determine a set of strategies appropriate for your community’s situation. Continue using the preparedness strategies implemented for no community transmission, and consider the following social distancing strategies:
@@ -19,5 +21,3 @@ Work with your local health officials to determine a set of strategies appropria
 * Limit nonessential visitors.
 * Limit bringing in students from other schools for special programs (e.g., music, robotics, academic clubs)
 * Teach staff, students, and their families to maintain a safe distance (6 feet) from each other in the school.
-
-

--- a/_content/k12-childcare/planning-and-preparedness/should-my-school-screen-students-for-cases-of-covid-19.md
+++ b/_content/k12-childcare/planning-and-preparedness/should-my-school-screen-students-for-cases-of-covid-19.md
@@ -1,13 +1,13 @@
 ---
-title: Should my school screen students for COVID-19?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: Should my school screen students for COVID-19?
 ---
 
 Schools and childcare programs are **not expected** to screen children, students, or staff to identify cases of COVID-19. If a community (or more specifically, a school) has cases of COVID-19, local health officials will help identify those individuals and follow up on next steps.
-

--- a/_content/k12-childcare/planning-and-preparedness/substantial-community-transmission.md
+++ b/_content/k12-childcare/planning-and-preparedness/substantial-community-transmission.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do when there is substantial community transmission?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should I do when there is substantial community transmission?
 ---
 
 If local health officials have determined there is substantial transmission of COVID-19 within the community, they will provide guidance to administrators on the best course of action for childcare programs or schools. These strategies are expected to extend across multiple programs, schools, or school districts within the community.

--- a/_content/k12-childcare/planning-and-preparedness/what-can-staff-and-students-do.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-can-staff-and-students-do.md
@@ -1,12 +1,13 @@
 ---
-title: What can staff and students do to prevent the spread of COVID-19?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What can staff and students do to prevent the spread of COVID-19?
 ---
 
 Encourage students and staff to take [everyday preventive actions](https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html) to prevent the spread of respiratory illnesses. These actions include staying home when sick; appropriately covering coughs and sneezes; cleaning and disinfecting frequently touched surfaces; and washing hands often with soap and water. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol. Always wash hands with soap and water if they are visibly dirty. Remember to supervise young children when they use hand sanitizer to prevent swallowing alcohol.

--- a/_content/k12-childcare/planning-and-preparedness/what-resources-does-cdc-have-available-to-share-with-staff-students-and-parents.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-resources-does-cdc-have-available-to-share-with-staff-students-and-parents.md
@@ -1,12 +1,13 @@
 ---
-title: What resources does CDC have available to share with staff, students, and parents?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What resources does CDC have available to share with staff, students, and parents?
 ---
 
 Share resources with the school community to help them understand COVID-19 and steps they can take to protect themselves:

--- a/_content/k12-childcare/planning-and-preparedness/what-should-i-consider-as-i-plan.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-should-i-consider-as-i-plan.md
@@ -1,12 +1,13 @@
 ---
-title: What should I consider as I plan and prepare for COVID-19?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should I consider as I plan and prepare for COVID-19?
 ---
 
 Administrators should always reinforce healthy practices among their staff and students, as well as prepare for a potential case of COVID-19, regardless of the current level of community transmission.

--- a/_content/k12-childcare/planning-and-preparedness/what-should-i-do-if-my-school-experiences-increased-rates-of-absenteeism.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-should-i-do-if-my-school-experiences-increased-rates-of-absenteeism.md
@@ -1,12 +1,14 @@
 ---
-title: What should I do if my school experiences increased rates of absenteeism?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Responding to confirmed
+  COVID-19 cases'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Responding to confirmed COVID-19 cases"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should I do if my school experiences increased rates of absenteeism?
 ---
 
 If your school notices a substantial increase in the number of students or staff missing school due to illness, report this to your local health officials.

--- a/_content/k12-childcare/planning-and-preparedness/what-should-i-include-emergency-operations.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-should-i-include-emergency-operations.md
@@ -1,12 +1,13 @@
 ---
-title: What should I include in my emergency operations plan?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should I include in my emergency operations plan?
 ---
 
 Review and update your emergency operations plan in collaboration with your [local health department](https://www.naccho.org/membership/lhd-directory). Focus on the components or annexes of the plans that address infectious disease outbreaks.

--- a/_content/k12-childcare/planning-and-preparedness/what-steps-should-my-school-take-if-a-student-or-staff-member-shows-symptoms-of-covid-19.md
+++ b/_content/k12-childcare/planning-and-preparedness/what-steps-should-my-school-take-if-a-student-or-staff-member-shows-symptoms-of-covid-19.md
@@ -1,12 +1,14 @@
 ---
-title: What steps should my school take if a student or staff member shows symptoms of COVID-19?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Planning and preparedness'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Planning and preparedness"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What steps should my school take if a student or staff member shows symptoms
+  of COVID-19?
 ---
 
 You should establish procedures to ensure students and staff who become sick at school or who arrive at school sick are sent home as soon as possible. Keep anyone sick separate from well students and staff until the [sick person can be sent home](https://www.cdc.gov/coronavirus/2019-ncov/if-you-are-sick/steps-when-sick.html).

--- a/_content/k12-childcare/recent-travel/school-recently-traveled-to-an-area-with-covid-19.md
+++ b/_content/k12-childcare/recent-travel/school-recently-traveled-to-an-area-with-covid-19.md
@@ -1,13 +1,14 @@
 ---
-title: What should my school do if someone has recently traveled to an area with COVID-19 or has a family member who has?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: Recent travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: Recent travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: What should my school do if someone has recently traveled to an area with COVID-19
+  or has a family member who has?
 ---
 
 Review updated [CDC information for travelers](https://www.cdc.gov/coronavirus/2019-ncov/travelers/index.html), including [FAQ for travelers](https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html), and consult with state and local health officials. Health officials may use CDC's Interim US Guidance for Risk Assessment and Public Health Management of Persons with Potential Coronavirus Disease 2019 (COVID-19) Exposure in Travel-associated or Community Settings to make recommendations. Individuals returning from travel to areas with community spread of COVID-19 must follow guidance they have received from health officials.
-

--- a/_content/k12-childcare/school-dismissals/if-schools-are-dismissed-students-keep-learning.md
+++ b/_content/k12-childcare/school-dismissals/if-schools-are-dismissed-students-keep-learning.md
@@ -1,12 +1,13 @@
 ---
-title: Are there ways for students to keep learning if we decide to dismiss schools?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: School dismissals'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: School dismissals"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: Are there ways for students to keep learning if we decide to dismiss schools?
 ---
 
 Yes, consider implementing e-learning plans, including digital and distance learning options as feasible and appropriate. Determine, in consultation with school district officials or other relevant state or local partners:

--- a/_content/k12-childcare/school-dismissals/school-dismissal-what-else-should-i-consider.md
+++ b/_content/k12-childcare/school-dismissals/school-dismissal-what-else-should-i-consider.md
@@ -1,12 +1,13 @@
 ---
-title: If I make the decision for school dismissal, what else should I consider?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: School dismissals'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: School dismissals"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: If I make the decision for school dismissal, what else should I consider?
 ---
 
 In the event of a school dismissal, extracurricular group activities and large events, such as performances, field trips, and sporting events should also be cancelled. This may require close coordination with other partners and organizations (e.g., high school athletics associations, music associations). In addition, discourage students and staff from gathering or socializing anywhere, like at a friend’s house, a favorite restaurant, or the local shopping mall.

--- a/_content/k12-childcare/school-dismissals/what-should-my-school-consider-re-opening.md
+++ b/_content/k12-childcare/school-dismissals/what-should-my-school-consider-re-opening.md
@@ -1,12 +1,14 @@
 ---
-title: If we dismiss school, what do we need to consider when re-opening the building to students?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: School dismissals'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: School dismissals"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: If we dismiss school, what do we need to consider when re-opening the building
+  to students?
 ---
 
 CDC is currently working on additional guidance to help schools determine when and how to re-open in an orderly manner. If you need immediate assistance with this, consult local health officials for guidance. Stay in touch with your local and state health department, as well as the Department of Education.

--- a/_content/k12-childcare/school-dismissals/when-should-i-dismiss.md
+++ b/_content/k12-childcare/school-dismissals/when-should-i-dismiss.md
@@ -1,12 +1,13 @@
 ---
-title: When should I dismiss our school/childcare program?
 category: k12-childcare
-layout: post
 date: March 19, 2020
-source: CDC
+excerpt: 'K-12 schools and childcare program administrators: School dismissals'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
-excerpt: "K-12 schools and childcare program administrators: School dismissals"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/schools-faq.html
+title: When should I dismiss our school/childcare program?
 ---
 
 Any decision about school dismissal or cancellation of school events should be made in coordination with your local health officials. Schools are not expected to make decisions about dismissals on their own.

--- a/_content/keeping-home-safe/family-reduce-risk.md
+++ b/_content/keeping-home-safe/family-reduce-risk.md
@@ -1,12 +1,13 @@
 ---
-title: What steps can my family take to reduce our risk of getting COVID-19?
 category: keeping-home-safe
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: What steps can my family take to reduce our risk of getting COVID-19?
 ---
 
 Practice everyday preventive actions to help reduce your risk of getting sick and remind everyone in your home to do the same. These actions are especially important for older adults and people who have severe chronic medical conditions.

--- a/_content/keeping-home-safe/how-can-family-prepare.md
+++ b/_content/keeping-home-safe/how-can-family-prepare.md
@@ -1,12 +1,13 @@
 ---
-title: How can my family and I prepare for COVID-19?
 category: keeping-home-safe
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: How can my family and I prepare for COVID-19?
 ---
 
 Create a household plan of action to help protect your health and the health of those you care about in the event of an outbreak of COVID-19 in your community:

--- a/_content/keeping-home-safe/if-someone-in-my-house-gets-sick.md
+++ b/_content/keeping-home-safe/if-someone-in-my-house-gets-sick.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do if someone in my house gets sick with COVID-19?
 category: keeping-home-safe
-layout: post
 date: April 13, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: What should I do if someone in my house gets sick with COVID-19?
 ---
 
 Most people who get COVID-19 will be able to recover at home. [CDC has directions](https://www.cdc.gov/coronavirus/2019-ncov/hcp/guidance-prevent-spread.html) for people who are recovering at home and their caregivers, including:

--- a/_content/keeping-home-safe/should-i-make-my-own-hand-sanitizer.md
+++ b/_content/keeping-home-safe/should-i-make-my-own-hand-sanitizer.md
@@ -1,12 +1,13 @@
 ---
-title: Should I make my own hand sanitizer if I can’t find it in the stores?
 category: keeping-home-safe
-layout: post
 date: March 28, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: Should I make my own hand sanitizer if I can’t find it in the stores?
 ---
 
 CDC recommends handwashing with soap and water for at least 20 seconds or, using alcohol-based hand sanitizer with at least 60% alcohol when soap and water are not available. These actions are part of [everyday preventive actions](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html?CDC_AA_refVal=https%3A%2F%2Fwww.cdc.gov%2Fcoronavirus%2F2019-ncov%2Fprepare%2Fprevention.html) individuals can take to slow the spread of respiratory diseases like COVID-19. 

--- a/_content/keeping-home-safe/soap-or-hand-sanitizer.md
+++ b/_content/keeping-home-safe/soap-or-hand-sanitizer.md
@@ -1,12 +1,13 @@
 ---
-title: Should I use soap and water or a hand sanitizer to protect against COVID-19?
 category: keeping-home-safe
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: Should I use soap and water or a hand sanitizer to protect against COVID-19?
 ---
 
 Handwashing is one of the best ways to protect yourself and your family from getting sick. Wash your hands often with soap and water for at least 20 seconds, especially after blowing your nose, coughing, or sneezing; going to the bathroom; and before eating or preparing food. If soap and water are not readily available, use an alcohol-based hand sanitizer with at least 60% alcohol.

--- a/_content/keeping-home-safe/which-cleaning-products.md
+++ b/_content/keeping-home-safe/which-cleaning-products.md
@@ -1,12 +1,13 @@
 ---
-title: What cleaning products should I use to protect against COVID-19?
 category: keeping-home-safe
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Keeping your home safe
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: What cleaning products should I use to protect against COVID-19?
 ---
 
 Clean and disinfect frequently touched surfaces such as tables, doorknobs, light switches, countertops, handles, desks, phones, keyboards, toilets, faucets, and sinks. If surfaces are dirty, clean them using detergent or soap and water prior to disinfection. To disinfect, most common EPA-registered household disinfectants will work. See CDC's [recommendations for household cleaning and disinfection](https://www.cdc.gov/coronavirus/2019-ncov/community/home/cleaning-disinfection.html).

--- a/_content/parents-and-children/are-children-at-risk.md
+++ b/_content/parents-and-children/are-children-at-risk.md
@@ -1,12 +1,13 @@
 ---
-title: Are children more at-risk?
 category: parents-and-children
-layout: post
 date: March  19, 2020
-source: CDC
+excerpt: COVID-19 and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "COVID-19 and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: Are children more at-risk?
 ---
 
 Information about [COVID-19 in children](https://www.cdc.gov/coronavirus/2019-ncov/faq.html) is somewhat limited, but the information that is available suggests that children with confirmed COVID-19 generally had mild symptoms. Person-to-person spread from or to children, as among adults, is thought to occur mainly via respiratory droplets produced when an infected person coughs, sneezes, or talks.  Recent studies indicate that people who are infected but do not have symptoms likely also play a role in the spread of COVID-19.

--- a/_content/parents-and-children/are-symptoms-of-COVID-19-different-in-children.md
+++ b/_content/parents-and-children/are-symptoms-of-COVID-19-different-in-children.md
@@ -1,12 +1,13 @@
 ---
-title: Are the symptoms of COVID-19 different in children than in adults?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
 excerpt: COVID-19 and children
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
+title: Are the symptoms of COVID-19 different in children than in adults?
 ---
 
 No. The symptoms of COVID-19 are similar in children and adults. However, children with confirmed COVID-19 have generally presented with mild symptoms. Reported symptoms in children include cold-like symptoms, such as fever, runny nose, and cough. Vomiting and diarrhea have also been reported. It’s not known yet whether some children may be at higher risk for severe illness, for example, children with underlying medical conditions and special healthcare needs. There is much more to be learned about how the disease impacts children.

--- a/_content/parents-and-children/how-can-i-prepare-in-case-my-childs-school-is-dismissed.md
+++ b/_content/parents-and-children/how-can-i-prepare-in-case-my-childs-school-is-dismissed.md
@@ -1,12 +1,14 @@
 ---
-title: How can I prepare in case my child's school, child care facility, or university is dismissed?
 category: parents-and-children
-layout: post
 date: March 28, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
 excerpt: Parents and children
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584388242595
+title: How can I prepare in case my child's school, child care facility, or university
+  is dismissed?
 ---
 
 Talk to the [school or facility](https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/index.html) about their emergency operations plan. Understand the plan for continuing education and social services (such as student meal programs) during school dismissals. If your child attends a [college or university](https://www.cdc.gov/coronavirus/2019-ncov/community/colleges-universities/index.html), encourage them to learn about the school’s plan for a COVID-19 outbreak.

--- a/_content/parents-and-children/how-can-i-protect-my-child-from-COVID-19.md
+++ b/_content/parents-and-children/how-can-i-protect-my-child-from-COVID-19.md
@@ -1,12 +1,13 @@
 ---
-title: How can I protect my child from COVID-19 infection?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
 excerpt: COVID-19 and children
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
+title: How can I protect my child from COVID-19 infection?
 ---
 
 You can encourage your child to help stop the spread of COVID-19 by teaching them to do the same things everyone should do to stay healthy.

--- a/_content/parents-and-children/how-should-parents-talk-to-children-about-covid19.md
+++ b/_content/parents-and-children/how-should-parents-talk-to-children-about-covid19.md
@@ -1,12 +1,13 @@
 ---
-title: How should parents talk to children about COVID-19?
 category: parents-and-children
-layout: post
 date: March  19, 2020
-source: CDC
+excerpt: COVID-19 and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "COVID-19 and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: How should parents talk to children about COVID-19?
 ---
 
 As public conversations around COVID-19 increase, children may worry about themselves, their family, and friends getting ill with COVID-19. Parents play an important role in helping children make sense of what they hear in a way that is honest, accurate, and minimizes anxiety or fear. CDC has created [guidance to help adults have conversations with children about COVID-19](https://www.cdc.gov/coronavirus/2019-ncov/community/schools-childcare/talking-with-children.html) and ways they can avoid getting and spreading the disease.

--- a/_content/parents-and-children/should-children-wear-face-masks.md
+++ b/_content/parents-and-children/should-children-wear-face-masks.md
@@ -1,15 +1,15 @@
 ---
-title: Should children wear facemasks?
 category: parents-and-children
-layout: post
 date: April 12, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
 excerpt: COVID-19 and children
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
+title: Should children wear facemasks?
 ---
 
 CDC recommends that everyone 2 years and older wear a cloth face covering that covers their nose and mouth when they are out in the community. Cloth face coverings should NOT be put on babies or children younger than 2 because of the danger of suffocation. Children younger than 2 years of age are listed as an exception as well as anyone who has trouble breathing or is unconscious, incapacitated, or otherwise unable to remove the face covering without assistance.
 
 Wearing cloth face coverings is a public health measure people should take to reduce the spread of COVID-19 in addition to (not instead of) social distancing, frequent hand cleaning, and other everyday preventive actions. A cloth face covering is not intended to protect the wearer but may prevent the spread of virus from the wearer to others. This would be especially important if someone is infected but does not have symptoms. Medical face masks and N95 respirators are still reserved for healthcare personnel and other first responders, as recommended by current CDC guidance.
-

--- a/_content/parents-and-children/what-is-the-risk-of-my-child-becoming-sick.md
+++ b/_content/parents-and-children/what-is-the-risk-of-my-child-becoming-sick.md
@@ -1,12 +1,13 @@
 ---
-title: What is the risk of my child becoming sick with COVID-19?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
 excerpt: COVID-19 and children
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584387482747
+title: What is the risk of my child becoming sick with COVID-19?
 ---
 
 Based on available evidence, children do not appear to be at higher risk for COVID-19 than adults. While some children and infants have been sick with COVID-19, adults make up most of the known cases to date. You can learn more about who is most at risk for health problems if they have COVID-19 infection on CDC’s current [Risk Assessment](https://www.cdc.gov/coronavirus/2019-ncov/summary.html#risk-assessment) page.

--- a/_content/parents-and-children/while-school-is-out-can-my-child-hang-with-friend.md
+++ b/_content/parents-and-children/while-school-is-out-can-my-child-hang-with-friend.md
@@ -1,12 +1,13 @@
 ---
-title: While school's out, can my child hang out with their friends?
 category: parents-and-children
-layout: post
 date: March 30, 2020
-source: CDC
+excerpt: School dismissals and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "School dismissals and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: While school's out, can my child hang out with their friends?
 ---
 
 * The key to slowing the spread of COVID-19 is to practice social distancing. While school is out, children should not have in-person playdates with children from other households. If children are playing outside their own homes, it is essential that they remain 6 feet from anyone who is not in their own household.

--- a/_content/parents-and-children/while-school-is-out-how-can-i-help-my-child-continue-learning.md
+++ b/_content/parents-and-children/while-school-is-out-how-can-i-help-my-child-continue-learning.md
@@ -1,12 +1,13 @@
 ---
-title: While school's out, how can I help my child continue learning?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
+excerpt: School dismissals and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "School dismissals and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: While school's out, how can I help my child continue learning?
 ---
 
 * Stay in touch with your child’s school.

--- a/_content/parents-and-children/while-school-is-out-how-can-i-keep-my-family-healthy.md
+++ b/_content/parents-and-children/while-school-is-out-how-can-i-keep-my-family-healthy.md
@@ -1,12 +1,13 @@
 ---
-title: While school's out, how can I keep my family healthy?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
+excerpt: School dismissals and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "School dismissals and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: While school's out, how can I keep my family healthy?
 ---
 
 * **Watch your child for any signs of illness.**
@@ -26,4 +27,3 @@ excerpt: "School dismissals and children"
 	* Reach out to friends and family via phone or video chats.
 	* Write cards or letters to family members they may not be able to visit.
 	* Some schools and non-profits, such as the [Collaborative for Academic, Social, and Emotional Learning](https://casel.org/) and [The Yale Center for Emotional Intelligence](http://ei.yale.edu/), have resources for social and emotional learning. Check to see if your school has tips and guidelines to help support social and emotional needs of your child.
-

--- a/_content/parents-and-children/while-school-is-out-will-kids-have-access-to-meals.md
+++ b/_content/parents-and-children/while-school-is-out-will-kids-have-access-to-meals.md
@@ -1,12 +1,13 @@
 ---
-title: While school's out, will kids have access to meals?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
+excerpt: School dismissals and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "School dismissals and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: While school's out, will kids have access to meals?
 ---
 
 * Check with your school on plans to continue meal services during the school dismissal. Many schools are keeping school facilities open to allow families to pick up meals or are providing grab-and-go meals at a central location.

--- a/_content/parents-and-children/while-shool-is-out-should-i-limit-time-with-older-adults.md
+++ b/_content/parents-and-children/while-shool-is-out-should-i-limit-time-with-older-adults.md
@@ -1,12 +1,14 @@
 ---
-title: While school's out, should I limit time with older adults, including relatives, and people with chronic medical conditions?
 category: parents-and-children
-layout: post
 date: March 23, 2020
-source: CDC
+excerpt: School dismissals and children
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
-excerpt: "School dismissals and children"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#school-dismissals
+title: While school's out, should I limit time with older adults, including relatives,
+  and people with chronic medical conditions?
 ---
 
 * [Older adults and people who have serious underlying medical conditions](https://www.cdc.gov/coronavirus/2019-ncov/specific-groups/people-at-higher-risk.html) are at highest risk of getting sick from COVID-19.

--- a/_content/pregnancy/can-covid-19-be-passed-from-a-pregnant-woman-to-her-fetus-or-newborn.md
+++ b/_content/pregnancy/can-covid-19-be-passed-from-a-pregnant-woman-to-her-fetus-or-newborn.md
@@ -1,12 +1,13 @@
 ---
-title: Can COVID-19 be passed from a mother to child?
 category: pregnancy
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: Can COVID-19 be passed from a mother to child?
 ---
 
 - Mother-to-child transmission of coronavirus during pregnancy is unlikely, but after birth a newborn is susceptible to person-to-person spread.

--- a/_content/pregnancy/can-covid19-cause-problems-for-pregnancy.md
+++ b/_content/pregnancy/can-covid19-cause-problems-for-pregnancy.md
@@ -1,12 +1,13 @@
 ---
-title: Can COVID-19 cause risks to the pregnancy and baby?
 category: pregnancy
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: Can COVID-19 cause risks to the pregnancy and baby?
 ---
 
 - Pregnant people have had a higher risk of severe illness when infected with viruses from the same family as COVID-19 and other viral respiratory infections, such as influenza.

--- a/_content/pregnancy/how-can-pregnant-women-protect-themselves-from-getting-covid-19.md
+++ b/_content/pregnancy/how-can-pregnant-women-protect-themselves-from-getting-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: How can pregnant women protect themselves from getting COVID-19?
 category: pregnancy
-layout: post
 date: March 17, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: How can pregnant women protect themselves from getting COVID-19?
 ---
 
 - Avoid people who are sick or who have been exposed to the virus.

--- a/_content/pregnancy/if-a-pregnant-woman-has-covid-19-during-pregnancy-will-it-hurt-the-baby.md
+++ b/_content/pregnancy/if-a-pregnant-woman-has-covid-19-during-pregnancy-will-it-hurt-the-baby.md
@@ -1,12 +1,13 @@
 ---
-title: If a pregnant woman has COVID-19 during pregnancy, will it hurt the baby?
 category: pregnancy
-layout: post
 date: March 17, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: If a pregnant woman has COVID-19 during pregnancy, will it hurt the baby?
 ---
 
 We do not know at this time what if any risk is posed to infants of a pregnant woman who has COVID-19. There have been a small number of reported problems with pregnancy or delivery (e.g. preterm birth) in babies born to mothers who tested positive for COVID-19 during their pregnancy. However, it is not clear that these outcomes were related to maternal infection.

--- a/_content/pregnancy/what-is-the-risk-to-pregnant-women-of-getting-COVID-19.md
+++ b/_content/pregnancy/what-is-the-risk-to-pregnant-women-of-getting-COVID-19.md
@@ -1,12 +1,13 @@
 ---
-title: What is the risk to pregnant women of getting COVID-19?
 category: pregnancy
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: What is the risk to pregnant women of getting COVID-19?
 ---
 
 We do not currently know if pregnant people have a greater chance of getting sick from COVID-19 than the general public nor whether they are more likely to have serious illness as a result. Based on available information, **pregnant people seem to have the same risk as adults who are not pregnant**.

--- a/_content/pregnancy/what-should-breastfeeding-mothers-do.md
+++ b/_content/pregnancy/what-should-breastfeeding-mothers-do.md
@@ -1,12 +1,14 @@
 ---
-title: What should breastfeeding mothers do if they are diagnosed with or under investigation for COVID-19?
 category: pregnancy
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
 excerpt: Pregnant women and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/prepare/pregnancy-breastfeeding.html
+title: What should breastfeeding mothers do if they are diagnosed with or under investigation
+  for COVID-19?
 ---
 
 - **Breast milk provides protection against many illnesses** and is the best source of nutrition for most infants.

--- a/_content/protect-yourself/am-i-at-risk-for-COVID-19-in-the-United-States.md
+++ b/_content/protect-yourself/am-i-at-risk-for-COVID-19-in-the-United-States.md
@@ -1,12 +1,13 @@
 ---
-title: Am I at risk for COVID-19 in the United States?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Am I at risk for COVID-19 in the United States?
 ---
 
 This is a rapidly evolving situation and the <a href="https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/summary.html#risk-assessment">risk assessment</a> may change daily. The latest updates are available on [CDC’s Coronavirus Disease 2019 (COVID-19) website](https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/summary.html).

--- a/_content/protect-yourself/am-i-at-risk-for-covid-19-from-packages-or-products-shipping-from-china.md
+++ b/_content/protect-yourself/am-i-at-risk-for-covid-19-from-packages-or-products-shipping-from-china.md
@@ -1,12 +1,13 @@
 ---
-title: Am I at risk for COVID-19 from packages or products shipping from China?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Am I at risk for COVID-19 from packages or products shipping from China?
 ---
 
 There is still a lot that is unknown about the newly emerged COVID-19 and how it spreads. Two other coronaviruses have emerged

--- a/_content/protect-yourself/how-can-I-help-protect-myself.md
+++ b/_content/protect-yourself/how-can-I-help-protect-myself.md
@@ -1,16 +1,14 @@
 ---
-title: How can I help protect myself?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#protect
 excerpt: How to protect yourself
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#protect
+title: How can I help protect myself?
 ---
 
 Visit the <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html?CDC_AA_refVal=https%3A%2F%2Fwww.cdc.gov%2Fcoronavirus%2F2019-ncov%2Fabout%2Fprevention.html"> COVID-19 Prevention and Treatment </a> page to learn about how to protect yourself from respiratory illnesses, like 
 COVID-19.
-
-
-

--- a/_content/protect-yourself/is-contact-lens-disinfecting-solution-effective-against-covid-19.md
+++ b/_content/protect-yourself/is-contact-lens-disinfecting-solution-effective-against-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Is contact lens disinfecting solution effective against COVID-19?
 category: protect-yourself
-layout: post
 date: April 8, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#accordion-5e8f163dd7986
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#accordion-5e8f163dd7986
+title: Is contact lens disinfecting solution effective against COVID-19?
 ---
 
 - [Hydrogen peroxide-based systems](https://www.cdc.gov/contactlenses/care-systems.html) for cleaning, disinfecting, and storing contact lenses should be effective against the virus that causes COVID-19.

--- a/_content/protect-yourself/is-it-okay-to-donate-blood.md
+++ b/_content/protect-yourself/is-it-okay-to-donate-blood.md
@@ -1,12 +1,13 @@
 ---
-title: Is it okay for me to donate blood?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Is it okay for me to donate blood?
 ---
 
 In healthcare settings all across the United States, donated blood is a lifesaving, essential part of caring for patients. The need for donated blood is constant, and blood centers are open and in urgent need of donations. CDC encourages people who are well to continue to donate blood if they are able, even if they are practicing social distancing because of COVID-19. CDC is supporting blood centers by providing recommendations that will keep donors and staff safe. Examples of these recommendations include spacing donor chairs 6 feet apart, thoroughly adhering to environmental cleaning practices, and encouraging donors to make donation appointments ahead of time.

--- a/_content/protect-yourself/should-contact-lens-wearers-take-extra-precaustions.md
+++ b/_content/protect-yourself/should-contact-lens-wearers-take-extra-precaustions.md
@@ -1,12 +1,13 @@
 ---
-title: Should contact lens wearers take special precautions to prevent COVID-19?
 category: protect-yourself
-layout: post
 date: April 8, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#accordion-5e8f163dd7986
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#accordion-5e8f163dd7986
+title: Should contact lens wearers take special precautions to prevent COVID-19?
 ---
 
 - Currently there is no evidence to suggest contact lens wearers are more at risk for acquiring COVID-19 than eyeglass wearers.

--- a/_content/protect-yourself/should-i-go-to-work-if-there-is-an-outbreak-in-my-community.md
+++ b/_content/protect-yourself/should-i-go-to-work-if-there-is-an-outbreak-in-my-community.md
@@ -1,12 +1,13 @@
 ---
-title: Should I go to work if there is an outbreak in my community?
 category: protect-yourself
-layout: post
 date: April 13, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#In-Case-of-an-Outbreak-in-Your-Community
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#In-Case-of-an-Outbreak-in-Your-Community
+title: Should I go to work if there is an outbreak in my community?
 ---
 
 Follow the advice of your local health officials. Stay home if you can. Talk to your employer to discuss working from home, taking leave if you or someone in your household gets sick with [COVID-19 symptoms](https://www.cdc.gov/coronavirus/2019-ncov/about/symptoms.html), or if your child’s school is dismissed temporarily. Employers should be aware that more employees may need to stay at home to care for sick children or other sick family members than is usual in case of a community outbreak.

--- a/_content/protect-yourself/six-feet-away-cloth-face-covering.md
+++ b/_content/protect-yourself/six-feet-away-cloth-face-covering.md
@@ -1,12 +1,14 @@
 ---
-title: Do I still need to stay at least 6 feet away from people if wearing a cloth face covering?
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Do I still need to stay at least 6 feet away from people if wearing a cloth
+  face covering?
 ---
 
-Yes. Wearing cloth face coverings is an additional public health measure people should take to reduce the spread of COVID-19. CDC still recommends that you stay at least 6 feet away from other people (social distancing), frequent hand cleaning and other everyday preventive actions. A cloth face covering is not intended to protect the wearer, but it may prevent the spread of virus from the wearer to others. This would be especially important if someone is infected but does not have symptoms. View CDC’s guidance on [how to protect yourself](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html).  
+Yes. Wearing cloth face coverings is an additional public health measure people should take to reduce the spread of COVID-19. CDC still recommends that you stay at least 6 feet away from other people (social distancing), frequent hand cleaning and other everyday preventive actions. A cloth face covering is not intended to protect the wearer, but it may prevent the spread of virus from the wearer to others. This would be especially important if someone is infected but does not have symptoms. View CDC’s guidance on [how to protect yourself](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html).

--- a/_content/protect-yourself/what-should-i-do-if-i-had-close-contact-with-someone-who-has-covid-19.md
+++ b/_content/protect-yourself/what-should-i-do-if-i-had-close-contact-with-someone-who-has-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: What should I do if I had close contact with someone who has COVID-19?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: What should I do if I had close contact with someone who has COVID-19?
 ---
 
 There is information for <a href="https://www.cdc.gov/coronavirus/2019-ncov/hcp/guidance-prevent-spread.html"> people who have had close contact,</a> with a person confirmed to have, or being evaluated for, COVID-19

--- a/_content/protect-yourself/what-should-people-at-higher-risk-of-serious-illness-with-covid-19-do.md
+++ b/_content/protect-yourself/what-should-people-at-higher-risk-of-serious-illness-with-covid-19-do.md
@@ -1,12 +1,13 @@
 ---
-title: What should people at higher risk of serious illness from COVID-19 do?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: What should people at higher risk of serious illness from COVID-19 do?
 ---
 
 If you are at higher risk of getting very sick from COVID-19, you should:

--- a/_content/protect-yourself/what-type-of-cloth-face-covering.md
+++ b/_content/protect-yourself/what-type-of-cloth-face-covering.md
@@ -1,12 +1,13 @@
 ---
-title: What type of cloth face covering should be worn? 
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: What type of cloth face covering should be worn?
 ---
 
-Cloth face coverings can be made from household items or made at home from common materials at low cost.  
+Cloth face coverings can be made from household items or made at home from common materials at low cost.

--- a/_content/protect-yourself/when-cloth-face-coverings.md
+++ b/_content/protect-yourself/when-cloth-face-coverings.md
@@ -1,12 +1,13 @@
 ---
-title: When do you need to wear a cloth face covering?
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: When do you need to wear a cloth face covering?
 ---
 
 A cloth face covering should be worn whenever people are in a community setting, especially in situations where you may be near people. These settings include grocery stores and pharmacies. These face coverings are not a substitute for social distancing. Cloth face coverings are especially important to wear in public in areas of widespread COVID-19 illness.

--- a/_content/protect-yourself/who-is-at-higher-risk-for-serious-illness-from-covid-19.md
+++ b/_content/protect-yourself/who-is-at-higher-risk-for-serious-illness-from-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Who is at higher risk for serious illness from COVID-19?
 category: protect-yourself
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
 excerpt: How to protect yourself
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Who is at higher risk for serious illness from COVID-19?
 ---
 
 **Older adults and people of any age who have serious underlying medical conditions** may be at higher risk for more serious complications from COVID-19. These people who may be at higher risk of getting very sick from this illness, includes:

--- a/_content/protect-yourself/who-should-not-wear-cloth-face-coverings.md
+++ b/_content/protect-yourself/who-should-not-wear-cloth-face-coverings.md
@@ -1,12 +1,13 @@
 ---
-title: Who should not wear cloth face coverings?
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Who should not wear cloth face coverings?
 ---
 
 Cloth face coverings should not be placed on young children younger than 2 years of age, anyone who has trouble breathing, or is unconscious, incapacitated or otherwise unable to remove the cover without assistance.

--- a/_content/protect-yourself/why-cloth-face-coverings-instead-of-facemasks.md
+++ b/_content/protect-yourself/why-cloth-face-coverings-instead-of-facemasks.md
@@ -1,12 +1,13 @@
 ---
-title: Why is CDC recommending cloth face coverings instead of medical grade facemasks? 
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Why is CDC recommending cloth face coverings instead of medical grade facemasks?
 ---
 
 Surgical masks and N95 respirators are in short supply and should be reserved for healthcare workers or other medical first responders, as recommended by CDC guidance.

--- a/_content/protect-yourself/why-cloth-face-coverings.md
+++ b/_content/protect-yourself/why-cloth-face-coverings.md
@@ -1,12 +1,13 @@
 ---
-title: Why do you need to wear cloth face coverings?
 category: protect-yourself
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: How to protect yourself
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
-excerpt: "How to protect yourself"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386949645
+title: Why do you need to wear cloth face coverings?
 ---
 
 In light of new data about [how COVID-19 spreads](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/how-covid-spreads.html), along with evidence of widespread COVID-19 illness in communities across the country, CDC recommends that people wear a [cloth face covering](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover.html) to cover their nose and mouth in the community setting. This is to protect people around you if you are infected but do not have symptoms.

--- a/_content/retirement-communities/case-in-the-facility/what-should-administrators-do-if-resident-or-staff-show-symptoms.md
+++ b/_content/retirement-communities/case-in-the-facility/what-should-administrators-do-if-resident-or-staff-show-symptoms.md
@@ -1,12 +1,13 @@
 ---
-title: What should administrators do if a resident or staff shows symptoms of COVID-19?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: What should administrators do if a resident or staff shows symptoms of COVID-19?
 ---
 
 Ask residents to actively monitor (at least daily) for [COVID-19 symptoms](https://www.cdc.gov/coronavirus/2019-ncov/about/symptoms.html), including fever and respiratory symptoms (shortness of breath, new or change in cough). Administrators should work with local health authorities to establish procedures for those who become sick. Sick residents should avoid contact with individuals who are healthy. If you think someone may have COVID-19, ask them to self-isolate and you should contact local health officials.

--- a/_content/retirement-communities/case-in-the-facility/what-should-administrators-do-if-there-is-a-case-covid-19-in-our-facility.md
+++ b/_content/retirement-communities/case-in-the-facility/what-should-administrators-do-if-there-is-a-case-covid-19-in-our-facility.md
@@ -1,12 +1,13 @@
 ---
-title: What should administrators do if there is a case of COVID-19 in our facility?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: What should administrators do if there is a case of COVID-19 in our facility?
 ---
 
 Work with local health authorities to communicate the possible exposure to residents, staff, and visitors. Clean and disinfect all shared facilities and high-touch surfaces. Limit visitors to essential staff  and visitors. Staff and, when possible, visitors should be screened for signs and symptoms of COVID-19 before entering the facility. Residents will need to actively monitor their health for COVID-19 symptoms. Cancel group activities. Residences that become ill should be advised to call the medical facility in advance of their visit. [See CDC’s full interim guidance for more details.](https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/guidance-retirement-response.html)

--- a/_content/retirement-communities/planning-and-preparedness/does-cdc-have-recommendations-for-cleaning-and-disinfecting-surfaces.md
+++ b/_content/retirement-communities/planning-and-preparedness/does-cdc-have-recommendations-for-cleaning-and-disinfecting-surfaces.md
@@ -1,12 +1,13 @@
 ---
-title: Does CDC have recommendations for cleaning and disinfecting surfaces?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: Does CDC have recommendations for cleaning and disinfecting surfaces?
 ---
 
 Routinely clean and disinfect frequently touched surfaces (e.g., doorknobs, light switches, countertops) with cleaners that you typically use. Use all cleaning products according to the directions on the label. [Practice strict infection control procedures if there is a case in your facility.](https://www.cdc.gov/coronavirus/2019-ncov/infection-control/index.html)

--- a/_content/retirement-communities/planning-and-preparedness/how-can-my-retirement-community-or-independent-living-facility-prepare.md
+++ b/_content/retirement-communities/planning-and-preparedness/how-can-my-retirement-community-or-independent-living-facility-prepare.md
@@ -1,12 +1,14 @@
 ---
-title: How can my retirement community or independent living facility prepare for COVID-19?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: How can my retirement community or independent living facility prepare for
+  COVID-19?
 ---
 
 [Administrators should take the following actions to prevent a COVID-19 outbreak in their community or facility:](https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/guidance-retirement-response.html)

--- a/_content/retirement-communities/planning-and-preparedness/what-actions-can-residents-and-staff-take-to-prevent-spread.md
+++ b/_content/retirement-communities/planning-and-preparedness/what-actions-can-residents-and-staff-take-to-prevent-spread.md
@@ -1,12 +1,13 @@
 ---
-title: What actions can residents and staff take to prevent the spread of COVID-19?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: What actions can residents and staff take to prevent the spread of COVID-19?
 ---
 
 Encourage residents and staff to take [everyday preventive actions](https://www.cdc.gov/coronavirus/2019-ncov/about/prevention-treatment.html) to prevent the spread of respiratory illnesses. Actions include staying home when sick; appropriately covering coughs and sneezes; [cleaning and then disinfecting frequently touched surfaces](https://www.cdc.gov/coronavirus/2019-ncov/community/organizations/cleaning-disinfection.html); and washing hands often with soap and water.

--- a/_content/retirement-communities/planning-and-preparedness/what-resources-does-cdc-have-available.md
+++ b/_content/retirement-communities/planning-and-preparedness/what-resources-does-cdc-have-available.md
@@ -1,12 +1,13 @@
 ---
-title: What resources does CDC have available to share with facilities?
 category: retirement-communities
-layout: post
 date: March 20, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
 excerpt: Retirement communities
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/community/retirement/faq.html
+title: What resources does CDC have available to share with facilities?
 ---
 
 Share resources with the community to help them understand COVID-19 and steps they can take to protect themselves:

--- a/_content/rumors/are-older-folks-the-only-ones-at-risk.md
+++ b/_content/rumors/are-older-folks-the-only-ones-at-risk.md
@@ -1,12 +1,14 @@
 ---
-title: Are older people and those with existing health conditions the only ones at risk?
 category: rumors
+date: March 26, 2020
+excerpt: Get the facts
 layout: post
 promoted: false
-date: March 26, 2020
-source: FEMA
-source_url: https://www.fema.gov/coronavirus-rumor-control
-excerpt: Get the facts
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Are older people and those with existing health conditions the only ones at
+  risk?
 ---
 
 Older adults and people with serious chronic medical conditions are at higher risk of serious illness. But anyone can become sick, and symptoms can range from mild to severe regardless of how old you are or if you have other medical conditions.

--- a/_content/rumors/are-there-any-vaccines.md
+++ b/_content/rumors/are-there-any-vaccines.md
@@ -1,12 +1,13 @@
 ---
-title: Are there any vaccines to prevent or medicines to treat COVID-19?
 category: rumors
-layout: post
 date: April 6, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Are there any vaccines to prevent or medicines to treat COVID-19?
 ---
 
 Currently, there are no Food and Drug Administration (FDA) approved drugs specifically for the treatment of COVID-19. Researchers are studying new drugs, and drugs that are already approved for other health conditions, as possible treatments for COVID-19. The Centers for Disease Control and Prevention has more information for health care providers about these potential treatments.

--- a/_content/rumors/are-uscis-offices-closed-for-covid.md
+++ b/_content/rumors/are-uscis-offices-closed-for-covid.md
@@ -1,12 +1,13 @@
 ---
-title: Are US Citizenship and Immigration Services offices closed due to COVID-19?
 category: rumors
-layout: post
 date: April 10, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.uscis.gov/about-us/uscis-response-coronavirus-2019-covid-19
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.uscis.gov/about-us/uscis-response-coronavirus-2019-covid-19
+title: Are US Citizenship and Immigration Services offices closed due to COVID-19?
 ---
 
 As of March 18, U.S. Citizenship and Immigration Services has temporarily suspended routine in-person services through at least May 3 to help slow the spread of coronavirus (COVID-19). USCIS staff will continue to perform mission critical duties that do not involve contact with the public. However, USCIS will provide emergency services for limited situations. To schedule an emergency appointment contact the [USCIS Contact Center](https://www.uscis.gov/contactcenter).

--- a/_content/rumors/did-fema-block-shipments-of-ventilators-to-my-state.md
+++ b/_content/rumors/did-fema-block-shipments-of-ventilators-to-my-state.md
@@ -1,12 +1,13 @@
 ---
-title: Did FEMA block shipments of ventilators to my state?
 category: rumors
-layout: post
 date: April 11, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Did FEMA block shipments of ventilators to my state?
 ---
 
 FEMA did not block shipments of ventilators to any state. FEMA works with HHS and federal partners to coordinate distribution of medical supplies and personal protective equipment (PPE), from multiple sources including the Strategic National Stockpile, private industry donations, federal interagency allocation, and vendor procurements. These shipments are being sent with prioritization given to the areas with greatest need.

--- a/_content/rumors/do-i-need-a-photo-id-to-be-tested.md
+++ b/_content/rumors/do-i-need-a-photo-id-to-be-tested.md
@@ -1,12 +1,14 @@
 ---
-title: Do I need a photo ID to be tested for COVID-19 at a Community Based Testing Center (CBST)?
 category: rumors
-layout: post
 date: April 6, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/Coronavirus-Rumor-Control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/Coronavirus-Rumor-Control
+title: Do I need a photo ID to be tested for COVID-19 at a Community Based Testing
+  Center (CBST)?
 ---
 
-To determine if you are a first responder or healthcare worker you will need to provide your official workplace photo ID in order to be priority tested for COVID-19 at a Community Based Testing Center (CBTS). 
+To determine if you are a first responder or healthcare worker you will need to provide your official workplace photo ID in order to be priority tested for COVID-19 at a Community Based Testing Center (CBTS).

--- a/_content/rumors/do-i-need-to-register-with-fema-to-be-considered-for-help.md
+++ b/_content/rumors/do-i-need-to-register-with-fema-to-be-considered-for-help.md
@@ -1,12 +1,14 @@
 ---
-title: Do I need to register with FEMA in order to be considered for COVID-19 help from the U.S. Small Business Administration?
 category: rumors
-layout: post
 date: April 11, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Do I need to register with FEMA in order to be considered for COVID-19 help
+  from the U.S. Small Business Administration?
 ---
 
 No. If you represent a small business or nonprofit, for information visit the [U.S. Small Business Administration’s COVID-19 loan resources page](https://www.sba.gov/page/coronavirus-covid-19-small-business-guidance-loan-resources).

--- a/_content/rumors/is-5g-phone-technology-linked.md
+++ b/_content/rumors/is-5g-phone-technology-linked.md
@@ -1,12 +1,13 @@
 ---
-title: Is 5G cell phone technology linked to the cause of coronavirus?
 category: rumors
-layout: post
 date: April 6, 2020
-source: FCC
-promoted: false
-source_url: https://www.fema.gov/Coronavirus-Rumor-Control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fcc
+  url: https://www.fema.gov/Coronavirus-Rumor-Control
+title: Is 5G cell phone technology linked to the cause of coronavirus?
 ---
 
 A worldwide online conspiracy theory has attempted to link 5G cell phone technology as being one of the causes of the coronavirus. Many cell towers have been set on fire as a result. 5G technology **does NOT** cause coronavirus.

--- a/_content/rumors/is-dhs-deploying-the-national-guard.md
+++ b/_content/rumors/is-dhs-deploying-the-national-guard.md
@@ -1,12 +1,13 @@
 ---
-title: Is DHS deploying the National Guard?
 category: rumors
-layout: post
 date: April 6, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/Coronavirus-Rumor-Control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/Coronavirus-Rumor-Control
+title: Is DHS deploying the National Guard?
 ---
 
 On March 22, President Trump directed the Secretary of Defense to permit full federal reimbursement, by FEMA, for some states’ use of their National Guard forces. The President’s action provides Governors continued command of their National Guard forces, while being federally funded under Title 32. Each state’s National Guard is still under the authority of the Governor and is working in concert with the Department of Defense.

--- a/_content/rumors/is-fema-deploying-the-military.md
+++ b/_content/rumors/is-fema-deploying-the-military.md
@@ -1,12 +1,13 @@
 ---
-title: Is FEMA deploying the military?
 category: rumors
-layout: post
 date: March 26, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Is FEMA deploying the military?
 ---
 
 No. FEMA does not have military personnel. State governors are responsible for deploying the National Guard if needed.

--- a/_content/rumors/is-fema-seizing-personal-protective-equipment.md
+++ b/_content/rumors/is-fema-seizing-personal-protective-equipment.md
@@ -1,12 +1,14 @@
 ---
-title: Is FEMA seizing Personal Protective Equipment (PPE) or re-routing medical supplies when it's delivered to the United States?
 category: rumors
-layout: post
 date: April 11, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Is FEMA seizing Personal Protective Equipment (PPE) or re-routing medical supplies
+  when it's delivered to the United States?
 ---
 
 FEMA and Customs Border Patrol (CBP) are working together to prevent fraud when PPE and medical supplies enter the United States from overseas. PPE being distributed internally within the United States is not being seized or re-routed by FEMA. Reports of FEMA seizing or re-routing supplies are FALSE.

--- a/_content/rumors/is-the-federal-government-mandating-businesses-to-close.md
+++ b/_content/rumors/is-the-federal-government-mandating-businesses-to-close.md
@@ -1,12 +1,13 @@
 ---
-title: Is the Federal government mandating businesses to close because of Coronavirus? 
 category: rumors
-layout: post
 date: March 30, 2020
-source: DHS
-promoted: false
-source_url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce 
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: dhs
+  url: https://www.cisa.gov/publication/guidance-essential-critical-infrastructure-workforce
+title: Is the Federal government mandating businesses to close because of Coronavirus?
 ---
 
 No. The Federal Government recognizes that State, local, tribal, and territorial governments are ultimately in charge of implementing and executing response activities in communities under their jurisdiction, while the Federal Government is in a supporting role.

--- a/_content/rumors/is-the-government-sending-everyone-money.md
+++ b/_content/rumors/is-the-government-sending-everyone-money.md
@@ -1,15 +1,15 @@
 ---
-title: Is the government sending everyone money?
 category: rumors
-layout: post
-promoted: false
 date: March 26, 2020
 excerpt: Get the facts
+layout: post
+promoted: false
 sources:
     - agency: fema
       url: https://www.fema.gov/coronavirus-rumor-control
     - agency: ftc
       url: https://www.consumer.ftc.gov/features/coronavirus-scams-what-ftc-doing
+title: Is the government sending everyone money?
 ---
 
 A stimulus package has been passed by Congress to help Americans in need. As information becomes available, it will be updated on this site.

--- a/_content/rumors/is-the-government-sending-everyone-money.md
+++ b/_content/rumors/is-the-government-sending-everyone-money.md
@@ -4,11 +4,12 @@ category: rumors
 layout: post
 promoted: false
 date: March 26, 2020
-source: FEMA
-source_2: FTC
-source_url: https://www.fema.gov/coronavirus-rumor-control
-source_url_2: https://www.consumer.ftc.gov/features/coronavirus-scams-what-ftc-doing
 excerpt: Get the facts
+sources:
+    - agency: fema
+      url: https://www.fema.gov/coronavirus-rumor-control
+    - agency: ftc
+      url: https://www.consumer.ftc.gov/features/coronavirus-scams-what-ftc-doing
 ---
 
 A stimulus package has been passed by Congress to help Americans in need. As information becomes available, it will be updated on this site.

--- a/_content/rumors/is-there-a-national-lockdown.md
+++ b/_content/rumors/is-there-a-national-lockdown.md
@@ -1,12 +1,13 @@
 ---
-title: Is there a national lockdown or quarantine?
 category: rumors
-layout: post
 date: March 26, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Is there a national lockdown or quarantine?
 ---
 
 No. States and cities are responsible for announcing curfews, shelters in place, or other restrictions and safety measures.

--- a/_content/rumors/on-medicare-and-someone-offered-me-a-test.md
+++ b/_content/rumors/on-medicare-and-someone-offered-me-a-test.md
@@ -1,12 +1,14 @@
 ---
-title: I'm on Medicare, and someone offered me a COVID-19 test if I provide my Medicare information? Should I accept?
 category: rumors
-layout: post
 date: April 6, 2020
-source: FEMA
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: I'm on Medicare, and someone offered me a COVID-19 test if I provide my Medicare
+  information? Should I accept?
 ---
 
 If you receive any calls like this, please know that it is a scam to get your private personal information. Beneficiaries are being targeted in a number of ways, including telemarketing calls, social media platforms, and door-to-door visits. Do not give out your Medicare, Medicaid, or Social security numbers. And be cautious about any unsolicited requests for your personal information. If you think you need to be tested for the Coronavirus, please call your doctor, who can advise you on what tests you may need.

--- a/_content/rumors/should-i-stock-up-on-food-and-supplies.md
+++ b/_content/rumors/should-i-stock-up-on-food-and-supplies.md
@@ -1,12 +1,13 @@
 ---
-title: Should I stock up on food and supplies?
 category: rumors
+date: March 26, 2020
+excerpt: Get the facts about coronavirus
 layout: post
 promoted: false
-date: March 26, 2020
-source: FEMA
-source_url: https://www.fema.gov/coronavirus-rumor-control
-excerpt: Get the facts about coronavirus
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+title: Should I stock up on food and supplies?
 ---
 
 Please only buy what your family needs for a week. Buying weeks or months of supplies in advance leads to shortages and makes it difficult for other families to take care of themselves. 

--- a/_content/rumors/should-i-worry-about-hantavirus.md
+++ b/_content/rumors/should-i-worry-about-hantavirus.md
@@ -1,14 +1,15 @@
 ---
-title: Should I worry about hantavirus?
 category: rumors
-layout: post
 date: March 26, 2020
-source: FEMA
-source_2: CDC
-promoted: false
-source_url: https://www.fema.gov/coronavirus-rumor-control
-source_url_2: https://www.cdc.gov/hantavirus/
 excerpt: Get the facts about coronavirus
+layout: post
+promoted: false
+sources:
+- agency: fema
+  url: https://www.fema.gov/coronavirus-rumor-control
+- agency: cdc
+  url: https://www.cdc.gov/hantavirus/
+title: Should I worry about hantavirus?
 ---
 
 No. The main way hantavirus spreads to people is through infected mice and rats. It is possible to catch hantavirus from another person, but it’s extremely rare. For more information about hantavirus, [visit the CDC’s website](https://www.cdc.gov/hantavirus/).

--- a/_content/spread/can-mosquitoes-spread-covid19.md
+++ b/_content/spread/can-mosquitoes-spread-covid19.md
@@ -1,12 +1,13 @@
 ---
-title: Can mosquitoes or ticks spread the virus that causes COVID-19?
 category: spread
-layout: post
 date: March 28, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Can mosquitoes or ticks spread the virus that causes COVID-19?
 ---
 
-At this time, CDC has no data to suggest that this new coronavirus or other similar coronaviruses are spread by mosquitoes or ticks. The main way that COVID-19 spreads is from person to person. See [how coronavirus spreads](/spread) for more information. 
+At this time, CDC has no data to suggest that this new coronavirus or other similar coronaviruses are spread by mosquitoes or ticks. The main way that COVID-19 spreads is from person to person. See [how coronavirus spreads](/spread) for more information.

--- a/_content/spread/can-someone-who-has-been-quarantined-for-COVID-19-spread-the-illness-to-others.md
+++ b/_content/spread/can-someone-who-has-been-quarantined-for-COVID-19-spread-the-illness-to-others.md
@@ -1,12 +1,13 @@
 ---
-title: Can someone who has been quarantined for COVID-19 spread the illness to others?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Can someone who has been quarantined for COVID-19 spread the illness to others?
 ---
 
 Quarantine means separating a person or group of people who have been exposed to a contagious disease but have not developed illness (symptoms) from others who have not been exposed, in order to prevent the possible spread of that disease. Quarantine is usually established for the incubation period of the communicable disease, which is the span of time during which people have developed illness after exposure. For COVID-19, the period of quarantine is 14 days from the last date of exposure, because 14 days is the longest incubation period seen for similar coronaviruses. Someone who has been released from COVID-19 quarantine is not considered a risk for spreading the virus to others because they have not developed illness during the incubation period.

--- a/_content/spread/can-someone-who-has-had-covid-19-spread-the-illness-to-others.md
+++ b/_content/spread/can-someone-who-has-had-covid-19-spread-the-illness-to-others.md
@@ -1,12 +1,13 @@
 ---
-title: Can someone who has had COVID-19 spread the illness to others?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Can someone who has had COVID-19 spread the illness to others?
 ---
 
 The virus that causes COVID-19 is [spreading from person-to-person](https://www.cdc.gov/coronavirus/2019-ncov/prepare/transmission.html). Someone who is actively sick with COVID-19 can spread the illness to others. That is why CDC recommends that these patients be isolated either in the hospital or at home (depending on how sick they are) until they are better and no longer pose a risk of infecting others.

--- a/_content/spread/can-the-virus-that-causes-covid-19-be-spread-through-food.md
+++ b/_content/spread/can-the-virus-that-causes-covid-19-be-spread-through-food.md
@@ -1,12 +1,13 @@
 ---
-title: Can the virus that causes COVID-19 be spread through food?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Can the virus that causes COVID-19 be spread through food?
 ---
 
 Coronaviruses are generally thought to be spread from person-to-person through respiratory droplets. Currently there is no evidence to support transmission of COVID-19 associated with food. Before preparing or eating food it is important to always wash your hands with soap and water for 20 seconds for general food safety. Throughout the day wash your hands after blowing your nose, coughing or sneezing, or going to the bathroom.

--- a/_content/spread/how-does-the-virus-spread.md
+++ b/_content/spread/how-does-the-virus-spread.md
@@ -1,12 +1,13 @@
 ---
-title: How does the virus spread?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: How does the virus spread?
 ---
 
 The virus that causes COVID-19 is thought to spread mainly from person to person, mainly through respiratory droplets produced when an infected person coughs or sneezes. These droplets can land in the mouths or noses of people who are nearby or possibly be inhaled into the lungs. Spread is more likely when people are in close contact with one another (within about 6 feet).

--- a/_content/spread/what-is-community-spread.md
+++ b/_content/spread/what-is-community-spread.md
@@ -1,12 +1,13 @@
 ---
-title: What is community spread?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: What is community spread?
 ---
 
 Community spread means people have been infected with the virus in an area, including some who are not sure how or where they became infected.

--- a/_content/spread/what-is-the-source-of-the-virus.md
+++ b/_content/spread/what-is-the-source-of-the-virus.md
@@ -1,12 +1,13 @@
 ---
-title: What is the source of the virus?
 category: spread
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: What is the source of the virus?
 ---
 
 COVID-19 is caused by a coronavirus called SARS-CoV-2. Coronaviruses are a large family of viruses that are common in people and may different species of animals, including camels, cattle, cats, and bats.  Rarely, animal coronaviruses can infect people and then spread between people. This occurred with [MERS-CoV](https://www.cdc.gov/coronavirus/mers/index.html) and [SARS-CoV](https://www.cdc.gov/sars/index.html), and now with the virus that causes COVID-19. More information about the source and spread of COVID-19 is available on the [Situation Summary: Source and Spread of the Virus](https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/summary.html#emergence).

--- a/_content/spread/what-temperature-kills-the-virus.md
+++ b/_content/spread/what-temperature-kills-the-virus.md
@@ -1,12 +1,13 @@
 ---
-title: What temperature kills the virus that causes COVID-19?
 category: spread
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: What temperature kills the virus that causes COVID-19?
 ---
 
 Generally coronaviruses survive for shorter periods of time at higher temperatures and higher humidity than in cooler or dryer environments. However, we don’t have direct data for this virus, nor do we have direct data for a temperature-based cutoff for inactivation at this point. The necessary temperature would also be based on the materials of the surface, the environment, etc. Regardless of temperature please follow [CDC’s guidance for cleaning and disinfection](https://www.cdc.gov/coronavirus/2019-ncov/prepare/protect-home.html).

--- a/_content/spread/why-are-we-seeing-a-rise-in-cases.md
+++ b/_content/spread/why-are-we-seeing-a-rise-in-cases.md
@@ -1,12 +1,13 @@
 ---
-title: Why are we seeing a rise in cases?
 category: spread
-layout: post
 date: March 28, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Why are we seeing a rise in cases?
 ---
 
 The [number of cases of COVID-19](https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/cases-in-us.html) being reported in the United States is rising due to [increased laboratory testing](https://www.cdc.gov/coronavirus/2019-ncov/cases-updates/testing-in-us.html) and reporting across the country. The growing number of cases in part reflects the rapid spread of COVID-19 as many U.S. states and territories experience community spread. More detailed and accurate data will allow us to better understand and track the size and scope of the outbreak and strengthen prevention and response efforts.

--- a/_content/spread/will-warm-weather-stop-the-outbreak-of-COVID-19.md
+++ b/_content/spread/will-warm-weather-stop-the-outbreak-of-COVID-19.md
@@ -1,14 +1,13 @@
 ---
-title: Will warm weather stop the outbreak of COVID-19?
 category: spread
-layout: post
 date: March 16, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
 excerpt: How it spreads
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584386553767
+title: Will warm weather stop the outbreak of COVID-19?
 ---
 
 It is not yet known whether weather and temperature impact the spread of COVID-19. Some other viruses, like the common cold and flu, spread more during cold weather months but that does not mean it is impossible to become sick with these viruses during other months.  At this time, it is not known whether the spread of COVID-19 will decrease when weather becomes warmer.  There is much more to learn about the transmissibility, severity, and other features associated with COVID-19 and investigations are ongoing.
-
-

--- a/_content/support-for-business/can-the-sba-help-me-with-other-assistance.md
+++ b/_content/support-for-business/can-the-sba-help-me-with-other-assistance.md
@@ -1,12 +1,13 @@
 ---
-title: Can the Small Business Administration help me with other assistance?
 category: support-for-business
-layout: post
 date: March 30, 2020
-source: Small Business Administration
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: sba
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: Can the Small Business Administration help me with other assistance?
 ---
 
 Yes, as it has for more than 65 years, the U.S. Small Business Administration is offering various trainings and educational assistance for small businesses across the country to help them start, grow, expand and recover. You can find your local SBA District Office at [www.sba.gov/localassistance](http://www.sba.gov/localassistance).

--- a/_content/support-for-business/employee-retention-credit.md
+++ b/_content/support-for-business/employee-retention-credit.md
@@ -1,14 +1,15 @@
 ---
-title: What is the Employee Retention Credit?
 category: support-for-business
-layout: post
 date: April 1, 2020
-source: Treasury
-source_2: IRS
+excerpt: 'Employee Retention Tax Credit: What You Need to Know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm962
-source_url_2: https://home.treasury.gov/system/files/136/Employee-Retention-Tax-Credit.pdf
-excerpt: "Employee Retention Tax Credit: What You Need to Know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm962
+- agency: irs
+  url: https://home.treasury.gov/system/files/136/Employee-Retention-Tax-Credit.pdf
+title: What is the Employee Retention Credit?
 ---
 
 The Employee Retention Credit is a refundable tax credit designed to encourage businesses to keep employees on their payroll. The refundable tax credit is 50 percent of up to $10,000 in wages paid by an eligible employer whose business has been financially impacted by COVID-19. The credit is available to all employers regardless of size, including tax-exempt organizations. There are only two exceptions: State and local governments and their instrumentalities and small businesses who take Small Business Loans. Qualifying employers must fall into one of two categories:

--- a/_content/support-for-business/how-to-apply-for-a-small-business-loan.md
+++ b/_content/support-for-business/how-to-apply-for-a-small-business-loan.md
@@ -1,14 +1,15 @@
 ---
-title: How do I apply for a small business loan?
 category: support-for-business
-layout: post
 date: March 31, 2020
-source: Treasury
-source_url: https://home.treasury.gov/news/press-releases/sm961
-source_2: Small Business Administration
-source_url_2: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm961
+- agency: small business administration
+  url: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
+title: How do I apply for a small business loan?
 ---
 
 The Paycheck Protection Program provides small businesses with funds to pay up to 8 weeks of payroll costs including benefits. Funds can also be used to pay interest on mortgages, rent, and utilities. Funds are provided in the form of loans that will be fully forgiven when used for payroll costs, interest on mortgages, rent, and utilities (due to likely high subscription, at least 75% of the forgiven amount must have been used for payroll). Loan payments will also be deferred for six months. No collateral or personal guarantees are required. Neither the government nor lenders will charge small businesses any fees.

--- a/_content/support-for-business/how-to-apply-for-a-small-business-loan.md
+++ b/_content/support-for-business/how-to-apply-for-a-small-business-loan.md
@@ -7,7 +7,7 @@ promoted: false
 sources:
 - agency: treasury
   url: https://home.treasury.gov/news/press-releases/sm961
-- agency: small business administration
+- agency: sba
   url: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
 title: How do I apply for a small business loan?
 ---

--- a/_content/support-for-business/how-to-apply-for-benefits.md
+++ b/_content/support-for-business/how-to-apply-for-benefits.md
@@ -1,14 +1,15 @@
 ---
-title: How do I apply for small business or self-employment benefits?
 category: support-for-business
-layout: post
 date: March 31, 2020
-source: Treasury
-source_url: https://home.treasury.gov/news/press-releases/sm961
-source_2: Small Business Administration
-source_url_2: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm961
+- agency: small business administration
+  url: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
+title: How do I apply for small business or self-employment benefits?
 ---
 
 Starting April 3, 2020, small businesses and sole proprietorships can apply. Starting April 10, 2020, independent contractors and self-employed individuals can apply. We encourage you to apply as quickly as you can because there is a funding cap.

--- a/_content/support-for-business/how-to-apply-for-benefits.md
+++ b/_content/support-for-business/how-to-apply-for-benefits.md
@@ -7,7 +7,7 @@ promoted: false
 sources:
 - agency: treasury
   url: https://home.treasury.gov/news/press-releases/sm961
-- agency: small business administration
+- agency: sba
   url: https://home.treasury.gov/system/files/136/PPP%20--%20Overview.pdf
 title: How do I apply for small business or self-employment benefits?
 ---

--- a/_content/support-for-business/small-medium-businesses-paid-leave.md
+++ b/_content/support-for-business/small-medium-businesses-paid-leave.md
@@ -1,14 +1,17 @@
 ---
-title: How do small and medium sized businesses provide paid sick and family leave for their workers?
 category: support-for-business
-layout: post
 date: April 1, 2020
-source: Treasury
-source_2: IRS
+excerpt: Treasury and IRS Release FAQs to Help Small and Midsize Businesses Navigate
+  Paid Sick and Family Leave Tax Credits
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm965
-source_url_2: https://www.irs.gov/newsroom/covid-19-related-tax-credits-for-required-paid-leave-provided-by-small-and-midsize-businesses-faqs#basic
-excerpt: "Treasury and IRS Release FAQs to Help Small and Midsize Businesses Navigate Paid Sick and Family Leave Tax Credits"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm965
+- agency: irs
+  url: https://www.irs.gov/newsroom/covid-19-related-tax-credits-for-required-paid-leave-provided-by-small-and-midsize-businesses-faqs#basic
+title: How do small and medium sized businesses provide paid sick and family leave
+  for their workers?
 ---
 
 The Families First Coronavirus Response Act (FFCRA), signed by President Trump on March 18, 2020, gives businesses with fewer than 500 employees funds to provide employees with paid sick leave and family and medical leave related to COVID-19.

--- a/_content/support-for-business/what-capital-assistance-is-available-to-small-business-owners.md
+++ b/_content/support-for-business/what-capital-assistance-is-available-to-small-business-owners.md
@@ -1,12 +1,13 @@
 ---
-title: What capital assistance is available to small business owners now?
 category: support-for-business
-layout: post
 date: March 30, 2020
-source: Small Business Administration
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: sba
+  url: https://www.irs.gov/newsroom/economic-impact-payments-what-you-need-to-know
+title: What capital assistance is available to small business owners now?
 ---
 
 SBA’s long-term, low-interest **Economic Injury Disaster Loans** and **Loan Advance** are currently available. In response to user feedback, the application is now easier and takes less processing time. You can find the application at [www.sba.gov/disaster](http://www.sba.gov/disaster). Additional programs will be available the coming days.

--- a/_content/support-for-business/what-resources-are-available-to-the-airline-industry.md
+++ b/_content/support-for-business/what-resources-are-available-to-the-airline-industry.md
@@ -1,12 +1,13 @@
 ---
-title: What resources are available to the airline industry and airline workers?
 category: support-for-business
-layout: post
 date: March 30, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm960
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm960
+title: What resources are available to the airline industry and airline workers?
 ---
 
 Treasury has released guidance for the airline industry regarding payroll support for air carriers and contractors, and procedures for loans.

--- a/_content/support-for-business/when-are-taxes-due-for-alcohol-tobacco-firearms-ammunition-businesses.md
+++ b/_content/support-for-business/when-are-taxes-due-for-alcohol-tobacco-firearms-ammunition-businesses.md
@@ -1,12 +1,13 @@
 ---
-title: When are taxes due for alcohol, tobacco, firearms, or ammunition businesses?
 category: support-for-business
-layout: post
 date: March 31, 2020
-source: Treasury
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: https://home.treasury.gov/news/press-releases/sm963
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: treasury
+  url: https://home.treasury.gov/news/press-releases/sm963
+title: When are taxes due for alcohol, tobacco, firearms, or ammunition businesses?
 ---
 
 The Treasury Department is delaying tax payment due dates for wine, beer, distilled spirits, tobacco products, firearms, and ammunition excise taxes to provide flexibility for businesses that have been hurt by the coronavirus. Tax payments that were originally due between March 1, 2020 and July 1, 2020 can now be delayed for up to 90 days after the original due date. If businesses are in need of additional support, they may contact the [Alcohol and Tobacco Tax and Trade Bureau](https://www.ttb.gov/contact-nrc) (TTB).

--- a/_content/support-for-business/where-should-a-small-business-go-to-find-help.md
+++ b/_content/support-for-business/where-should-a-small-business-go-to-find-help.md
@@ -1,12 +1,14 @@
 ---
-title: Where should a small business go to find help in response to the Coronavirus pandemic?
 category: support-for-business
-layout: post
 date: March 30, 2020
-source: Small Business Administration
+excerpt: 'Economic impact payments: What you need to know'
+layout: post
 promoted: false
-source_url: http://www.sba.gov/coronavirus
-excerpt: "Economic impact payments: What you need to know"
+sources:
+- agency: sba
+  url: http://www.sba.gov/coronavirus
+title: Where should a small business go to find help in response to the Coronavirus
+  pandemic?
 ---
 
 Stay up to date with the U.S. Small Business Administration’s assistance at by visiting [www.sba.gov/coronavirus](http://www.sba.gov/coronavirus), following [@SBAgov](http://www.twitter.com/SBAGov) on Twitter, and subscribing to SBA’s e-updates via [www.sba.gov/updates](http://www.sba.gov/updates).

--- a/_content/symptoms-and-testing/can-a-person-test-negative-and-later-test-positive-for-covid-19.md
+++ b/_content/symptoms-and-testing/can-a-person-test-negative-and-later-test-positive-for-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Can a person test negative and later test positive for COVID-19?
 category: symptoms-and-testing
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
 excerpt: Symptoms and testing
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
+title: Can a person test negative and later test positive for COVID-19?
 ---
 
 Using the CDC-developed diagnostic test, a negative result means that the virus that causes COVID-19 was not found in the person’s sample. In the early stages of infection, it is possible the virus will not be detected.

--- a/_content/symptoms-and-testing/if-i-recover-from-covid19-will-i-be-immune.md
+++ b/_content/symptoms-and-testing/if-i-recover-from-covid19-will-i-be-immune.md
@@ -1,12 +1,13 @@
 ---
-title: If I have recovered from COVID-19, will I be immune to it?
 category: symptoms-and-testing
-layout: post
 date: April 14, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
 excerpt: Symptoms and testing
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
+title: If I have recovered from COVID-19, will I be immune to it?
 ---
 
 CDC and partners are investigating to determine if you can get sick with COVID-19 more than once. At this time, we are not sure if you can become re-infected. Until we know more, continue to take steps to protect yourself and others.

--- a/_content/symptoms-and-testing/kind-of-test-used-to-diagnose-covid19.md
+++ b/_content/symptoms-and-testing/kind-of-test-used-to-diagnose-covid19.md
@@ -1,12 +1,13 @@
 ---
-title: What kind of test is being used to diagnose if I have COVID-19?
 category: symptoms-and-testing
-layout: post
 date: April 14, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
 excerpt: Symptoms and testing
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
+title: What kind of test is being used to diagnose if I have COVID-19?
 ---
 
 Many tests to diagnose COVID-19 have received an [Emergency Use Authorization (EUA)](https://www.fda.gov/medical-devices/emergency-situations-medical-devices/emergency-use-authorizations) from the Food & Drug Administration (FDA). All of these diagnostic tests identify the virus in samples from the respiratory system, such as from nasopharyngeal swabs.

--- a/_content/symptoms-and-testing/should-i-be-tested-for-covid-19.md
+++ b/_content/symptoms-and-testing/should-i-be-tested-for-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Should I be tested for COVID-19?
 category: symptoms-and-testing
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
 excerpt: Symptoms and testing
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
+title: Should I be tested for COVID-19?
 ---
 
 Not everyone needs to be tested for COVID-19. For information about testing, see [Testing for COVID-19](https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/testing.html).

--- a/_content/symptoms-and-testing/what-are-the-symptoms-and-complications-that-covid-19-can-cause.md
+++ b/_content/symptoms-and-testing/what-are-the-symptoms-and-complications-that-covid-19-can-cause.md
@@ -1,15 +1,15 @@
 ---
-title: What are the symptoms and complications that COVID-19 can cause?
 category: symptoms-and-testing
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
 excerpt: Symptoms and testing
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
+title: What are the symptoms and complications that COVID-19 can cause?
 ---
 
 Current symptoms reported for patients with COVID-19 have included mild to severe respiratory illness with fever<sup>1</sup>, cough, and difficulty breathing. Read about [COVID-19](https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html) Symptoms.
 
 <sub>1. Fever may be subjective or confirmed</sub>
-

--- a/_content/symptoms-and-testing/what-is-serology-testing.md
+++ b/_content/symptoms-and-testing/what-is-serology-testing.md
@@ -1,12 +1,13 @@
 ---
-title: What is serology testing? And can I be tested using this method?
 category: symptoms-and-testing
-layout: post
 date: April 14, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
 excerpt: Symptoms and testing
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Symptoms-&-Testing
+title: What is serology testing? And can I be tested using this method?
 ---
 
 Serology testing checks a sample of a person’s blood to look for antibodies to SARS-CoV-2, the virus that causes COVID-19. These antibodies are produced when someone has been infected, so a positive result from this test indicates that person was previously infected with the virus.

--- a/_content/symptoms-and-testing/where-can-i-get-tested.md
+++ b/_content/symptoms-and-testing/where-can-i-get-tested.md
@@ -1,12 +1,13 @@
 ---
-title: Where can I get tested for COVID-19?
 category: symptoms-and-testing
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
 excerpt: Symptoms and testing
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#anchor_1584389201096
+title: Where can I get tested for COVID-19?
 ---
 
 The process and locations for testing vary from place to place. Contact your state, local, tribal, or territorial department for more information, or reach out to a medical provider. State and local public health departments have received tests from CDC while medical providers are getting tests developed by commercial manufacturers. While supplies of these tests are increasing, it may still be difficult to find someplace to get tested. See [Testing for COVID-19](https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/testing.html) for more information.

--- a/_content/travel/are-the-northern-southern-us-borders-closed.md
+++ b/_content/travel/are-the-northern-southern-us-borders-closed.md
@@ -1,12 +1,13 @@
 ---
-title: Are the Northern and Southern Borders of the United States closed?
 category: travel
-layout: post
 date: March 31, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
+title: Are the Northern and Southern Borders of the United States closed?
 ---
 
 In order to limit the further spread of coronavirus, the U.S. has reached agreements with both Canada and Mexico to limit all non-essential travel across borders.
@@ -17,4 +18,3 @@ Supply chains, including trucking, will not be impacted by this measure.
 Those who cross the land border every day to do essential work or for other urgent or essential reasons, and that travel will not be impacted.
 
 These measures were implemented on March 21, 2020.
-

--- a/_content/travel/are-undocumented-immigrants-still-being-held.md
+++ b/_content/travel/are-undocumented-immigrants-still-being-held.md
@@ -1,16 +1,18 @@
 ---
-title: Are illegal immigrants being held by Customs and Border Protection (CBP) during the Coronavirus pandemic?
 category: travel
-layout: post
 date: March 31, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
+title: Are illegal immigrants being held by Customs and Border Protection (CBP) during
+  the Coronavirus pandemic?
 ---
 
 To help prevent the introduction of Coronavirus into our border facilities and into our country, illegal aliens subject to the order will not be held by CBP, and instead will immediately be turned away from ports of entry.
 
 Those encountered between ports of entry after illegally crossing the border similarly will not be held for processing and instead, will immediately be returned to their country of last transit.  
 
-These aliens are processed in stations designed for short-term processing, where distancing is not a viable option, creating serious danger of an outbreak.  
+These aliens are processed in stations designed for short-term processing, where distancing is not a viable option, creating serious danger of an outbreak.

--- a/_content/travel/can-american-citizen-return-recently-traveled.md
+++ b/_content/travel/can-american-citizen-return-recently-traveled.md
@@ -1,12 +1,14 @@
 ---
-title: I’m an American citizen and I recently traveled to one of the countries under travel restrictions. Can I return to the United States? 
 category: travel
-layout: post
 date: March 30, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
+title: I’m an American citizen and I recently traveled to one of the countries under
+  travel restrictions. Can I return to the United States?
 ---
 
 Yes. American citizens, legal permanent residents, and their immediate families can return to the United States. 

--- a/_content/travel/can-american-citizen-return-to-us.md
+++ b/_content/travel/can-american-citizen-return-to-us.md
@@ -1,12 +1,14 @@
 ---
-title: I’m an American citizen and I recently traveled to one of the countries under travel restrictions. Can I return to the United States? 
 category: travel
-layout: post
 date: March 30, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
+title: I’m an American citizen and I recently traveled to one of the countries under
+  travel restrictions. Can I return to the United States?
 ---
 
 Yes. American citizens, legal permanent residents, and their immediate families can return to the United States. 

--- a/_content/travel/return-to-work-international-travel.md
+++ b/_content/travel/return-to-work-international-travel.md
@@ -1,12 +1,13 @@
 ---
-title: When can I return to work after international travel?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
+title: When can I return to work after international travel?
 ---
 
 Currently, all international travelers arriving into the US should stay home for 14 days after their arrival. At home, they are expected to monitor their health and practice social distancing. To protect the health of others, these travelers should not to go to work or school for 14 days.

--- a/_content/travel/should-I-cancel-my-international-travel.md
+++ b/_content/travel/should-I-cancel-my-international-travel.md
@@ -1,12 +1,13 @@
 ---
-title: Should I cancel my international trip?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Canceling and postponing travel'
+layout: post
 promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#canceling-postponing-travel
-excerpt: "Travel: Canceling and postponing travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#canceling-postponing-travel
+title: Should I cancel my international trip?
 ---
 
 **CDC recommends that travelers avoid all nonessential international travel because of the COVID-19 pandemic.** Some health care systems are overwhelmed and there may be limited access to adequate medical care in affected areas. Many countries are implementing travel restrictions and mandatory quarantines, closing borders, and prohibiting non-citizens from entry with little advance notice. Airlines have cancelled many international flights and in-country travel may be unpredictable. If you choose to travel internationally, your travel plans may be disrupted, and you may have to remain outside the United States for an indefinite length of time.

--- a/_content/travel/should-i-go-on-a-cruise.md
+++ b/_content/travel/should-i-go-on-a-cruise.md
@@ -1,12 +1,13 @@
 ---
-title: Should I go on a cruise?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Air or cruise travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
-excerpt: "Travel: Air or cruise travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
+title: Should I go on a cruise?
 ---
 
 CDC recommends that all travelers [defer all cruise ship travel worldwide](https://wwwnc.cdc.gov/travel/page/covid-19-cruise-ship). Recent reports of COVID-19 on cruise ships highlight the risk of infection to cruise ship passengers and crew. Like many other viruses, COVID-19 appears to spread more easily between people in close quarters aboard ships.

--- a/_content/travel/should-i-travel-within-the-us.md
+++ b/_content/travel/should-i-travel-within-the-us.md
@@ -1,12 +1,13 @@
 ---
-title: Should I travel within the United States?
 category: travel
-layout: post
 date: March 30, 2020
-source: CDC
+excerpt: 'Travel: Canceling or postponing travel'
+layout: post
 promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-in-the-us.html
-excerpt: "Travel: Canceling or postponing travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-in-the-us.html
+title: Should I travel within the United States?
 ---
 
 CDC does not generally issue advisories or restrictions for travel within the United States. However, cases of coronavirus disease (COVID-19) have been reported in many states, and some areas are experiencing community spread of the disease. Crowded travel settings, like airports, may increase chances of getting COVID-19, if there are other travelers with coronavirus infection. There are several things you should consider when deciding whether it is safe for you to travel.

--- a/_content/travel/should-travelers-wear-facemasks.md
+++ b/_content/travel/should-travelers-wear-facemasks.md
@@ -1,12 +1,13 @@
 ---
-title: Should travelers wear facemasks or coverings?
 category: travel
-layout: post
 date: April 03, 2020
-source: CDC
+excerpt: 'Travel: Air or cruise travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html
-excerpt: "Travel: Air or cruise travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html
+title: Should travelers wear facemasks or coverings?
 ---
 
 In the context of the COVID-19 pandemic, CDC recommends that everyone wear a [cloth face covering](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover.html) over their nose and mouth when in the community setting, including during travel if they must travel. This as an additional public health measure people should take to reduce the spread of COVID-19 in addition to (not instead of) social distancing, frequent hand cleaning and other [everyday preventive actions](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html). A cloth face covering is not intended to protect the wearer, but may prevent the spread of virus from the wearer to others. This would be especially important in the event that someone is infected but does not have symptoms. Medical masks and N-95 respirators are still reserved for healthcare workers and other first responders, as recommended by current CDC guidance.

--- a/_content/travel/sick-passenger-on-my-flight.md
+++ b/_content/travel/sick-passenger-on-my-flight.md
@@ -1,12 +1,13 @@
 ---
-title: What happens if there is a sick passenger on my flight?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Air or cruise travel'
+layout: post
 promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
-excerpt: "Travel: Air or cruise travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
+title: What happens if there is a sick passenger on my flight?
 ---
 
 Under current federal regulations, pilots must report all illnesses and deaths to CDC before arriving to a US destination. According to CDC disease protocols, if a sick traveler is considered to be a public health risk, CDC works with local and state health departments and international public health agencies to [contact passengers and crew](https://www.cdc.gov/quarantine/contact-investigation.html) exposed to that sick traveler.

--- a/_content/travel/what-can-I-expect-when-arriving-to-the-united-states.md
+++ b/_content/travel/what-can-I-expect-when-arriving-to-the-united-states.md
@@ -1,12 +1,13 @@
 ---
-title: What can I expect when arriving to the United States?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
+title: What can I expect when arriving to the United States?
 ---
 
 At this time, travel restrictions and entry screening apply only to travelers arriving from some countries or regions with widespread ongoing spread of COVID-19. [Note: US policies are subject to change as the COVID-19 pandemic evolves.]

--- a/_content/travel/what-can-i-expect-when-departing-other-countries.md
+++ b/_content/travel/what-can-i-expect-when-departing-other-countries.md
@@ -1,12 +1,13 @@
 ---
-title: What can I expect when departing from other countries?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
+title: What can I expect when departing from other countries?
 ---
 
 Be aware that some countries are conducting exit screening for all passengers leaving their country. Before being permitted to board a departing flight, you may have your temperature taken and be asked questions about your travel history and health.

--- a/_content/travel/what-if-i-recently-traveled-and-get-sick.md
+++ b/_content/travel/what-if-i-recently-traveled-and-get-sick.md
@@ -1,12 +1,13 @@
 ---
-title: What if I recently traveled and get sick?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#returning-from-travel
+title: What if I recently traveled and get sick?
 ---
 
 <a href="https://www.cdc.gov/coronavirus/2019-ncov/about/steps-when-sick.html"> See CDC’s website about what to do if you get sick</a>.

--- a/_content/travel/what-is-the-risk-of-getting-covid-19-on-an-airplane.md
+++ b/_content/travel/what-is-the-risk-of-getting-covid-19-on-an-airplane.md
@@ -1,12 +1,13 @@
 ---
-title: What is the risk of getting COVID-19 on an airplane?
 category: travel
-layout: post
 date: March 27, 2020
-source: CDC
+excerpt: 'Travel: Air or cruise travel'
+layout: post
 promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
-excerpt: "Travel: Air or cruise travel"
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/travelers/faqs.html#air-cruise-travel
+title: What is the risk of getting COVID-19 on an airplane?
 ---
 
 Because of how air circulates and is filtered on airplanes, most viruses and other germs do not spread easily. Although the risk of infection on an airplane is low, try to avoid contact with sick passengers and wash your hands often with soap and water for at least 20 seconds or use hand sanitizer that contains at least 60% alcohol.

--- a/_content/travel/when-will-the-borders-reopen.md
+++ b/_content/travel/when-will-the-borders-reopen.md
@@ -1,12 +1,13 @@
 ---
-title: When will the borders reopen?
 category: travel
-layout: post
 date: March 31, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/23/fact-sheet-dhs-measures-border-limit-further-spread-coronavirus
+title: When will the borders reopen?
 ---
 
 Limits on non-essential travel were implemented on March 21, 2020 and will be in place for 30 days, at which point it will be reviewed by the United States, Canada and Mexico.

--- a/_content/travel/which-airports-have-enhanced-travel-screening.md
+++ b/_content/travel/which-airports-have-enhanced-travel-screening.md
@@ -1,12 +1,14 @@
 ---
-title: Which 13 airports have the enhanced travel screening measures for international travelers?
 category: travel
-layout: post
 date: March 30, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
+title: Which 13 airports have the enhanced travel screening measures for international
+  travelers?
 ---
 
 - Chicago O’Hare International Airport (ORD), Illinois

--- a/_content/travel/which-countries-are-subject-travel-restrictions-us.md
+++ b/_content/travel/which-countries-are-subject-travel-restrictions-us.md
@@ -1,12 +1,13 @@
 ---
-title: Which countries are under U.S. travel restrictions because of the Coronavirus?
 category: travel
-layout: post
 date: March 30, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/17/fact-sheet-dhs-notice-arrival-restrictions-china-iran-and-certain-countries-europe
+title: Which countries are under U.S. travel restrictions because of the Coronavirus?
 ---
 
 - Iran

--- a/_content/travel/will-read-id-implementation-be-delayed.md
+++ b/_content/travel/will-read-id-implementation-be-delayed.md
@@ -1,12 +1,13 @@
 ---
-title: Will Real ID implementation be delayed?
 category: travel
-layout: post
 date: March 26, 2020
-source: DHS
+excerpt: 'Travel: Returning from travel'
+layout: post
 promoted: false
-source_url: https://www.dhs.gov/news/2020/03/26/acting-secretary-chad-wolf-statement-real-id-enforcement-deadline
-excerpt: "Travel: Returning from travel"
+sources:
+- agency: dhs
+  url: https://www.dhs.gov/news/2020/03/26/acting-secretary-chad-wolf-statement-real-id-enforcement-deadline
+title: Will Real ID implementation be delayed?
 ---
 
-Yes. Department of Homeland Security Acting Secretary Chad F. Wolf has indicated the new deadline for REAL ID enforcement is October 1, 2021. 
+Yes. Department of Homeland Security Acting Secretary Chad F. Wolf has indicated the new deadline for REAL ID enforcement is October 1, 2021.

--- a/_content/underlying-conditions/are-people-with-disabilities-at-higher-risk.md
+++ b/_content/underlying-conditions/are-people-with-disabilities-at-higher-risk.md
@@ -1,12 +1,13 @@
 ---
-title: Are people with disabilities at higher risk?
 category: underlying-conditions
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
+title: Are people with disabilities at higher risk?
 ---
 
 Most people with disabilities are not inherently at higher risk for becoming infected with or having severe illness from COVID-19. Some people with physical limitations or other disabilities might be at a higher risk of infection because of their underlying medical condition.

--- a/_content/underlying-conditions/are-there-any-medications-i-should-avoid.md
+++ b/_content/underlying-conditions/are-there-any-medications-i-should-avoid.md
@@ -1,12 +1,13 @@
 ---
-title: Are there any medications I should avoid taking if I have COVID-19?
 category: underlying-conditions
-layout: post
 date: April 10, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Higher-Risk
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#Higher-Risk
+title: Are there any medications I should avoid taking if I have COVID-19?
 ---
 
 Currently, there is no evidence to show that taking ibuprofen or naproxen can lead to a more severe infection of COVID-19.

--- a/_content/underlying-conditions/how-were-the-underlying-conditions-selected.md
+++ b/_content/underlying-conditions/how-were-the-underlying-conditions-selected.md
@@ -1,12 +1,13 @@
 ---
-title: How were the underlying conditions selected?
 category: underlying-conditions
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
+title: How were the underlying conditions selected?
 ---
 
 This list is based on:

--- a/_content/underlying-conditions/what-about-underlying-medical-conditions-that-are-not-included-on-this-list.md
+++ b/_content/underlying-conditions/what-about-underlying-medical-conditions-that-are-not-included-on-this-list.md
@@ -1,12 +1,13 @@
 ---
-title: What about underlying medical conditions that are not included on this list?
 category: underlying-conditions
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
+title: What about underlying medical conditions that are not included on this list?
 ---
 
 Based on available information, adults aged 65 years and older and people of any age with underlying medical conditions included on this list are at higher risk for severe illness and poorer outcomes from COVID-19. CDC is collecting and analyzing data regularly and will update the list when we learn more. People with underlying medical conditions not on the list might also be at higher risk and should consult with their healthcare provider if they are concerned.

--- a/_content/underlying-conditions/what-does-more-sever-illness-mean.md
+++ b/_content/underlying-conditions/what-does-more-sever-illness-mean.md
@@ -1,12 +1,13 @@
 ---
-title: What does more severe illness mean?
 category: underlying-conditions
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
+title: What does more severe illness mean?
 ---
 
 Severity typically means how much impact the illness or condition has on your body’s function.  You should talk with your healthcare provider if you have a question about your health or how your health condition is being managed.

--- a/_content/underlying-conditions/what-does-well-controlled-mean.md
+++ b/_content/underlying-conditions/what-does-well-controlled-mean.md
@@ -1,12 +1,13 @@
 ---
-title: What does well controlled mean?
 category: underlying-conditions
-layout: post
 date: March 23, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
 excerpt: Underlying conditions
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#conditions
+title: What does well controlled mean?
 ---
 
 Generally, well-controlled means that your condition is stable, not life-threatening, and laboratory assessments and other findings are as similar as possible to those without the health condition. You should talk with your healthcare provider if you have a question about your health or how your health condition is being managed.

--- a/_content/underlying-conditions/who-is-at-higher-risk-for-serious-illness-from-covid-19.md
+++ b/_content/underlying-conditions/who-is-at-higher-risk-for-serious-illness-from-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Who is at higher risk for serious illness from COVID-19?
 category: underlying-conditions
-layout: post
 date: April 4, 2020
-source: CDC
-promoted: true
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#high-risk
 excerpt: Underlying conditions
+layout: post
+promoted: true
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/faq.html#high-risk
+title: Who is at higher risk for serious illness from COVID-19?
 ---
 
 COVID-19 is a new disease and there is limited information regarding risk factors for severe disease. Based on currently available information and clinical expertise, **older adults** and **people of any age who have serious underlying medical conditions** might be at higher risk for severe illness from COVID-19.

--- a/_content/water-transmission/additional-information-about-water-transmission-and-covid-19.md
+++ b/_content/water-transmission/additional-information-about-water-transmission-and-covid-19.md
@@ -1,12 +1,13 @@
 ---
-title: Where can I find additional information about water transmission and COVID-19?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Where can I find additional information about water transmission and COVID-19?
 ---
 
 * <a href="https://www.cdc.gov/healthywater/global/sanitation/workers_handlingwaste.html">CDC: Guidance for reducing health risks to workers handling human waste or sewage</a>

--- a/_content/water-transmission/can-the-covid-19-virus-spread-through-drinking-water.md
+++ b/_content/water-transmission/can-the-covid-19-virus-spread-through-drinking-water.md
@@ -1,12 +1,13 @@
 ---
-title: Can the COVID-19 virus spread through drinking water?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Can the COVID-19 virus spread through drinking water?
 ---
 
 The virus that causes COVID-19 has not been detected in drinking water. Conventional water treatment methods that use filtration and disinfection, such as those in most municipal drinking water systems, should remove or inactivate the virus that causes COVID-19.

--- a/_content/water-transmission/can-the-covid-19-virus-spread-through-pools-and-hot-tubs.md
+++ b/_content/water-transmission/can-the-covid-19-virus-spread-through-pools-and-hot-tubs.md
@@ -1,12 +1,13 @@
 ---
-title: Can the COVID-19 virus spread through pools, hot tubs or spas, and water playgrounds?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Can the COVID-19 virus spread through pools, hot tubs or spas, and water playgrounds?
 ---
 
 There is no evidence that COVID-19 can be spread to humans through the use of pools, hot tubs or spas, or water playgrounds. Proper operation, maintenance, and disinfection (e.g., with chlorine and bromine) of pools, hot tubs or spas, and water playgrounds should inactivate the virus that causes COVID-19.

--- a/_content/water-transmission/can-the-covid-19-virus-spread-through-sewerage-systems.md
+++ b/_content/water-transmission/can-the-covid-19-virus-spread-through-sewerage-systems.md
@@ -1,12 +1,13 @@
 ---
-title: Can the COVID-19 virus spread through sewerage systems?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Can the COVID-19 virus spread through sewerage systems?
 ---
 
 CDC is reviewing all data on COVID-19 transmission as information becomes available. At this time, the risk of transmission of the virus that causes COVID-19 through sewerage systems is thought to be low. Although transmission of the virus that causes COVID-19 through sewage may be possible, there is no evidence to date that this has occurred. This guidance will be updated as necessary as new evidence is assessed.

--- a/_content/water-transmission/if-utility-issued-boil-water-advisory-can-i-use-tap-water-to-wash-hands.md
+++ b/_content/water-transmission/if-utility-issued-boil-water-advisory-can-i-use-tap-water-to-wash-hands.md
@@ -1,12 +1,14 @@
 ---
-title: If my utility has issued a Boil Water Advisory, can I still use tap water to wash my hands?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: If my utility has issued a Boil Water Advisory, can I still use tap water to
+  wash my hands?
 ---
 
 In most cases, it is safe to [wash your hands](https://www.cdc.gov/handwashing/index.html) with soap and tap water during a [Boil Water Advisory](https://www.cdc.gov/healthywater/emergency/drinking/drinking-water-advisories/boil-water-advisory.html). Follow the guidance from your local public health officials. If soap and water are not available, use an alcohol-based hand sanitizer containing at least 60% alcohol.

--- a/_content/water-transmission/is-the-covid-19-virus-found-in-feces.md
+++ b/_content/water-transmission/is-the-covid-19-virus-found-in-feces.md
@@ -1,12 +1,13 @@
 ---
-title: Is the COVID-19 virus found in feces?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Is the COVID-19 virus found in feces?
 ---
 
 The virus that causes COVID-19 has been detected in the feces of some patients diagnosed with COVID-19. The amount of virus released from the body (shed) in stool, how long the virus is shed, and whether the virus in stool is infectious are not known.

--- a/_content/water-transmission/should-wasterwater-workers-take-extra-precautions-to-protect-from-covid19.md
+++ b/_content/water-transmission/should-wasterwater-workers-take-extra-precautions-to-protect-from-covid19.md
@@ -1,12 +1,14 @@
 ---
-title: Should wastewater workers take extra precautions to protect themselves from the COVID-19 virus?
 category: water-transmission
-layout: post
 date: April 3, 2020
-source: CDC
-promoted: false
-source_url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
 excerpt: Water transmission and COVID-19
+layout: post
+promoted: false
+sources:
+- agency: cdc
+  url: https://www.cdc.gov/coronavirus/2019-ncov/php/water.html
+title: Should wastewater workers take extra precautions to protect themselves from
+  the COVID-19 virus?
 ---
 
 Wastewater treatment plant operations should ensure workers follow routine practices to prevent exposure to wastewater. These include using engineering and administrative controls, safe work practices, and [PPE](https://www.cdc.gov/coronavirus/2019-ncov/php/water.html) normally required for work tasks when handling untreated wastewater. No additional COVID-19–specific protections are recommended for employees involved in wastewater management operations, including those at wastewater treatment facilities.

--- a/_includes/sources.html
+++ b/_includes/sources.html
@@ -1,26 +1,12 @@
-{%- if question.source and question.source_2 -%}
-| <cite>Sources: <a href="{{ question.source_url }}" class="usa-link">
-    {{ question.source }}
-    {%- if question.source_url contains "coronavirus.gov" -%}
-    {%- else -%}
-    <span class="usa-sr-only">links to external site</span>
-    {%- endif -%}
-</a>,
-<a href="{{ question.source_url_2 }}" class="usa-link">
-    {{ question.source_2 }}
-    {%- if question.source_url_2 contains "coronavirus.gov" -%}
-    {%- else -%}
-    <span class="usa-sr-only">links to external site</span>
-    {%- endif -%}
-</a>
+|<cite> Source{% if question.sources.size > 1 %}s{% endif %}:
+    {%- for source in question.sources -%}
+        {% assign current_source = site.agencies | where:"name", source.agency | first %}
+        <a href="{{ source.url }}" class="usa-link">
+        {{ current_source.title }}
+        {%- if source.url contains "coronavirus.gov" -%}
+        {%- else -%}
+        <span class="usa-sr-only">links to external site</span>
+        {%- endif -%}
+    </a>{% if forloop.last == false %}, {% endif %}
+    {%- endfor -%}
 </cite>
-{%- elsif question.source -%}
-| <cite>Source: <a href="{{ question.source_url }}" class="usa-link">
-    {{ question.source }}
-    {%- if question.source_url contains "coronavirus.gov" -%}
-    {%- else -%}
-    <span class="usa-sr-only">links to external site</span>
-    {%- endif -%}
-</a>
-</cite>
-{%- endif -%}

--- a/_layouts/agency.html
+++ b/_layouts/agency.html
@@ -4,13 +4,24 @@ sitemap: false
 ---
 
 {% assign all_categories = site.categories | sort: "title" %}
-{% assign all_by_category = site.content | where:"source", page.name | sort: "-date" | group_by:"category" %}
-{% assign total = site.content | where:"source", page.name %}
+
+<!-- Build array of content with this agency listed as a source-->
+{% assign content = "" | split: "," %}
+
+{% for content_page in site.content %}
+  {% for source in content_page.sources %}
+    {% if source.agency == page.name %}
+      {% assign content = content | push: content_page %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+
+{% assign all_by_category = content | sort: "-date" | group_by:"category" %}
 
 <section class="grid-container usa-section usa-section--condensed border-top border-base-lightest">
     <div class="grid-row">
       <div class="grid-col-12">
-        <h1>{{page.name}} ({{total | size}} total)</h1>
+        <h1>{{page.title}} ({{content | size}} total)</h1>
       </div>
     {% for category in all_categories %}
         {% assign current_category_questions = all_by_category | where:"name", category.name | first %}

--- a/agency/index.md
+++ b/agency/index.md
@@ -16,11 +16,20 @@ sitemap: false
     <div class="grid-row">
         <div class="grid-col-12">
         {% for agency in agencies %}
-            {% assign all = site.content | where:"source", agency.name %}
-            {% assign all_by_category = site.content | where:"source", agency.name | group_by:"category"  %}
+            <!-- Build array of content with this agency listed as a source-->
+            {% assign content = "" | split: "," %}
+            {% for content_page in site.content %}
+                {% for source in content_page.sources %}
+                    {% if source.agency == agency.name %}
+                    {% assign content = content | push: content_page %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+
+            {% assign all_by_category = content | where:"source", agency.name | group_by:"category"  %}
             {% assign all_categories = site.categories | sort: "title" %}
             <div>
-                <h2><a href="{{ site.baseurl }}{{ agency.url}}">{{agency.name}} ({{ all | size }} total)</a></h2>
+                <h2><a href="{{ site.baseurl }}{{ agency.url}}">{{agency.title}} ({{ content.size }} total)</a></h2>
                 <ul>
                     {% for category in all_categories %}
                         {% assign current_category_questions = all_by_category | where:"name", category.name | first %}

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -44,7 +44,9 @@ test(`every question's source references an agency that exists in ${agencyDirect
   const agencies = await helpers.getAllFilesInDirectory(agencyDirectory);
 
   contentFiles.forEach(file => {
-    const expectedAgencyFile = `${path.join(agencyDirectory, file.frontMatter.source)}.md`;
-    expect(agencies).toContain(expectedAgencyFile);
+    sources = file.frontMatter.sources.forEach(source => {
+      const expectedAgencyFile = `${path.join(agencyDirectory, source.agency)}.md`;
+      expect(agencies).toContain(expectedAgencyFile);
+    })
   });
 })


### PR DESCRIPTION
For #522 

Proposing a new structure in which to store `source` information for each question on the site.

With this change we can store and render `N` sources within the frontmatter of each question.
Example:
```yaml
sources:
    - agency: gsa
      url: https://gsa.gov
    - agency: 18f
      url: https://18f.gsa.gov
```

Includes updated frontmatter for _every_ question to convert source information into the new structure.

Frontmatter was modified w/ [this python script](https://gist.github.com/Jkrzy/a9e2861f135ac09a09994899a3712e2d) locally and commited to repo. 

Potentially complicating review, this had the side effect of re-ordering the frontmatter for each file. It is now alphabetical and consistent across all files. If overly burdensome I'll investigate approaches to maintain existing ordering of frontmatter attributes.
