### PR TITLE
Adds link to translated pregnancy FAQ

### DIFF
--- a/_content/pregnancy/what-should-breastfeeding-mothers-do.md
+++ b/_content/pregnancy/what-should-breastfeeding-mothers-do.md
@@ -18,5 +18,5 @@ excerpt: Pregnant women and COVID-19
   - Express breast milk to establish and maintain milk supply.
   - A dedicated breast pump should be provided.
   - Wash hands before touching any pump or bottle parts and before expressing breast milk.
-  - Follow **recommendations for proper pump cleaning** after each use, cleaning all parts that come into contact with breast milk.
+  - Follow **recommendations for proper pump cleaning** ([español](https://www.cdc.gov/healthywater/hygiene/healthychildcare/infantfeeding/breastpump-esp.html)) after each use, cleaning all parts that come into contact with breast milk.
   - If possible, consider having someone who is well feed the expressed breast milk to the infant.

--- a/_content/pregnancy/what-should-breastfeeding-mothers-do.md
+++ b/_content/pregnancy/what-should-breastfeeding-mothers-do.md
@@ -18,5 +18,5 @@ excerpt: Pregnant women and COVID-19
   - Express breast milk to establish and maintain milk supply.
   - A dedicated breast pump should be provided.
   - Wash hands before touching any pump or bottle parts and before expressing breast milk.
-  - Follow **recommendations for proper pump cleaning** ([español](https://www.cdc.gov/healthywater/hygiene/healthychildcare/infantfeeding/breastpump-esp.html)) after each use, cleaning all parts that come into contact with breast milk.
+  - Follow **recommendations for proper pump cleaning** ([Español](https://www.cdc.gov/healthywater/hygiene/healthychildcare/infantfeeding/breastpump-esp.html)) after each use, cleaning all parts that come into contact with breast milk.
   - If possible, consider having someone who is well feed the expressed breast milk to the infant.


### PR DESCRIPTION
- Adds link to translated version

_It seems to me the relevant text ("recommendations for proper pump cleaning") should be translated inline. The current link text implies users will read the preceding English text to understand where the link goes._