### PR TITLE
Remove homepage_order from medication

### DIFF
--- a/_categories/medications.md
+++ b/_categories/medications.md
@@ -3,7 +3,6 @@ layout: category
 name: medications
 title: "Medications"
 owner: FDA
-homepage_order: 18
 banner:
   display: false
   heading: "This is a place to place urgent information"


### PR DESCRIPTION
The `homepage_order` front matter is no longer needed for category sorting. These have been removed from all other categories, this one was added after the initial PR however.