### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-template.md
+++ b/.github/ISSUE_TEMPLATE/content-template.md
@@ -13,4 +13,3 @@ assignees: ''
 - [ ] Approved and merged from content administrator
 - [ ] Merged to production by engineer
 - [ ] Notified agency content lead that content is published
-- [ ] Closes issue on the board (auto-closing an issue)

--- a/.github/ISSUE_TEMPLATE/content-template.md
+++ b/.github/ISSUE_TEMPLATE/content-template.md
@@ -1,0 +1,16 @@
+---
+name: Content template
+about: Issue template for content changes
+title: ''
+labels: content
+assignees: ''
+
+---
+
+## Description
+
+## Definition of Done
+- [ ] Approved and merged from content administrator
+- [ ] Merged to production by engineer
+- [ ] Notified agency content lead that content is published
+- [ ] Closes issue on the board (auto-closing an issue)

--- a/.github/ISSUE_TEMPLATE/engineering-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/engineering-issue-template.md
@@ -1,0 +1,37 @@
+---
+name: Engineering issue template
+about: Issue template for Github engineering issues
+title: ''
+labels: engineering
+assignees: ''
+
+---
+
+## Description
+- _What is the problem we're trying to solve?_
+
+- _What problem does this issue address for the public?_
+
+- _How does this issue address the problem?_
+
+- _How will we know that the problem is resolved?_
+
+## Notes
+[Additional context, known dependencies, blockers, links to design documents, etc]
+
+## Acceptance Criteria
+- [ ]
+
+## Tasks
+- [ ] PO approved
+- [ ] Usability tested
+
+## Definition of Done
+- [ ] Pull requests meet technical definition of done
+- [ ] Code is properly styled per USWDS
+- [ ] Finished design has been compared against mockup
+- [ ] Documentation is complete
+- [ ] CircleCI tests have passed
+- [ ] Automated accessibility scans have passed
+- [ ] Manual accessibility testing completed
+- [ ] Code has been successfully built and deployed into a staging (dev) environment


### PR DESCRIPTION
Added issue templates for content and engineering. Both include a definition of done checklist, and the engineering issue template includes other details including acceptance criteria and other tasks. 

Resolves #550 