### PR TITLE
Adds edited USDA FAQs

### DIFF
--- a/_content/financial-help/what-happens-to-snap-recipients-who-cannot-meet-work-requirements-due-to-covid19.md
+++ b/_content/financial-help/what-happens-to-snap-recipients-who-cannot-meet-work-requirements-due-to-covid19.md
@@ -1,0 +1,13 @@
+---
+category: financial-help
+date: April 26, 2020
+excerpt: Supplemental Nutrition Assistance Program (SNAP) online pilot
+layout: post
+promoted: false
+sources:
+- agency: usda
+  url:  https://www.usda.gov/coronavirus
+title: What happens to SNAP recipients who can’t meet the work requirements due to the coronavirus outbreak?
+---
+
+Under the Families First Coronavirus Response Act, signed into law by President Trump on March 18, 2020, USDA has suspended the work requirements for able-bodied adults without dependents (ABAWDs) throughout the national emergency. Therefore, the time limit does not apply, and these individuals can continue to receive SNAP benefits.

--- a/_content/parents-and-children/what-action-is-being-taken-to-ensure-children-have-food-while-schools-are-closed.md
+++ b/_content/parents-and-children/what-action-is-being-taken-to-ensure-children-have-food-while-schools-are-closed.md
@@ -1,0 +1,17 @@
+---
+category: parents-and-children
+date: April  26, 2020
+excerpt: COVID-19, children, and access to food
+layout: post
+promoted: false
+sources:
+- agency: usda
+  url: https://www.usda.gov/coronavirus
+title: What action is being taken to ensure children have food to eat while schools are closed?
+---
+
+States switch to their [Summer Food Service Program (SFSP)](https://www.fns.usda.gov/sfsp/summer-food-service-program) or [Seamless Summer Option (SSO)](https://www.fns.usda.gov/sfsp/seamless-summer-and-other-options-schools) to serve meals to children when schools are closed. Through these summer meal programs, the U.S. Department of Agriculture (USDA) allows sites to serve up to two free meals a day to children 18 and under.
+
+The Families First Coronavirus Response Act, signed by President Trump on March 18, 2020, allows USDA the ability to issue nationwide waivers to further increase flexibilities. USDA Food and Nutrition Service (FNS) has issued [several nationwide waivers](https://www.fns.usda.gov/disaster/pandemic/covid-19/cn-waivers-flexibilities) to make it as easy as possible for children to receive these meals. As a result of these waivers, schools and other sponsors are creatively feeding kids by delivering meals on bus routes, allowing parents to pick up a weeks’ worth of meals at a time, and entering into public private partnerships like [USDA’s partnership](https://www.usda.gov/media/press-releases/2020/03/17/usda-announces-feeding-program-partnership-response-covid-19) with the Baylor Collaborative on Hunger and Poverty, McLane Global, and PepsiCo, which is providing meals kids in rural areas. USDA FNS has a current list of [approved waivers](http://www.fns.usda.gov/coronavirus) and [meal sites near you](http://www.fns.usda.gov/meals4kids).
+
+The Families First Coronavirus Response Act also provides states with the option to provide EBT benefits to children who would normally be receiving free and reduced priced meals if schools were not closed due to COVID-19, known as Pandemic EBT or P-EBT. USDA has provided guidance to states on operating this program and continues to provide technical assistance to interested states. For logistical information about meal service, please contact your local state agency or school food authority.

--- a/_content/protect-yourself/can-the-public-still-visit-national-forest-recreation-sites.md
+++ b/_content/protect-yourself/can-the-public-still-visit-national-forest-recreation-sites.md
@@ -1,0 +1,15 @@
+---
+category: protect-yourself
+date: April 26, 2020
+excerpt: How to protect yourself
+layout: post
+promoted: false
+sources:
+- agency: usda
+  url: https://www.usda.gov/coronavirus
+title: Can the public still visit National Forest recreation sites and facilities? If so, how can they do so safely?
+---
+
+In coordination with state and local health and safety guidelines, National Forests remain open however recreation services at our facilities may be changed, suspended or offered through alternate approaches as we manage for the health and safety of our work force and the public. Agency direction tasks local managers to perform risk assessments of our facilities and limit congregations of people and person to person interactions. Our decisions will align with local city, county and state actions to provide for human health and safety (i.e., quarantine, curfew, and other social restrictions).
+
+Visitors to our National Forests are urged to take the [precautions recommended by the Centers for Disease Control and Prevention (CDC)](https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html?CDC_AA_refVal=https%3A%2F%2Fwww.cdc.gov%2Fcoronavirus%2F2019-ncov%2Fprepare%2Fprevention.html). 


### PR DESCRIPTION
There are 4 USDA FAQs where we recommended the following revisions:

- Combine two FAQs (Will National Forest recreation sites and facilities stay open?) and (What can the public do to practice social distancing while recreating on National Forest System lands?) into a single FAQ - [**"Can the public still visit National Forest recreation sites and facilities? If so, how can they do safely?"**](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/edits-usda-4-27/protect-yourself/can-the-public-still-visit-national-forest-recreation-sites/)
- Remove url link to a PDF for state agency directors, not the general public for one FAQ: [**What happens to SNAP recipients who can’t meet the work requirements due to the coronavirus outbreak?**](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/edits-usda-4-27/financial-help/what-happens-to-snap-recipients-who-cannot-meet-work-requirements-due-to-covid19/)
- Fix typo for one FAQ:[ **What action is being taken to ensure children have food to eat while schools are closed?**](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/edits-usda-4-27/parents-and-children/what-action-is-being-taken-to-ensure-children-have-food-while-schools-are-closed/); edits the first sentence of last paragraph as follows: “The Families First Coronavirus Response Act also provides states with the option to provide EBT benefits…