### PR TITLE
[Do not merge] WIP agency loop for footer

### DIFF
--- a/_agencies/cdc.md
+++ b/_agencies/cdc.md
@@ -2,5 +2,6 @@
 layout: agency
 name: cdc
 title: "CDC"
+link: https://www.cdc.gov/
 sitemap: false
 ---

--- a/_agencies/dhs.md
+++ b/_agencies/dhs.md
@@ -2,5 +2,6 @@
 layout: agency
 name: dhs
 title: "DHS"
+link: https://www.dhs.gov/
 sitemap: false
 ---

--- a/_agencies/fcc.md
+++ b/_agencies/fcc.md
@@ -2,5 +2,6 @@
 layout: agency
 name: fcc
 title: "FCC"
+link: https://www.fcc.gov/
 sitemap: false
 ---

--- a/_agencies/fda.md
+++ b/_agencies/fda.md
@@ -2,5 +2,6 @@
 layout: agency
 name: fda
 title: "FDA"
+link: https://www.fda.gov/home
 sitemap: false
 ---

--- a/_agencies/fema.md
+++ b/_agencies/fema.md
@@ -2,5 +2,6 @@
 layout: agency
 name: fema
 title: "FEMA"
+link: https://www.fema.gov/
 sitemap: false
 ---

--- a/_agencies/ftc.md
+++ b/_agencies/ftc.md
@@ -2,5 +2,6 @@
 layout: agency
 name: ftc
 title: "FTC"
+link: https://www.ftc.gov/
 sitemap: false
 ---

--- a/_agencies/irs.md
+++ b/_agencies/irs.md
@@ -2,5 +2,6 @@
 layout: agency
 name: irs
 title: "IRS"
+link: https://www.irs.gov/
 sitemap: false
 ---

--- a/_agencies/sba.md
+++ b/_agencies/sba.md
@@ -2,6 +2,7 @@
 layout: agency
 name: sba
 permalink: /agency/sba/
-title: "Small Business Administration"
+title: "SBA"
+link: https://www.sba.gov/
 sitemap: false
 ---

--- a/_agencies/treasury.md
+++ b/_agencies/treasury.md
@@ -2,5 +2,6 @@
 layout: agency
 name: treasury
 title: "Treasury"
+link: https://home.treasury.gov/
 sitemap: false
 ---

--- a/_agencies/usda.md
+++ b/_agencies/usda.md
@@ -2,5 +2,6 @@
 layout: agency
 name: usda
 title: "USDA"
+link: https://www.usda.gov/
 sitemap: false
 ---

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
           {% assign agencies = site.agencies %}
           <ul>
           {% for agency in agencies %}
-            <li><a href="{{ agency.link }}">{{ agency.title }}</a></li>
+            <li><a href="{{ agency.link }}">{{ agency.title }}.gov</a></li>
           {% endfor %}
           </ul>
         </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,12 +3,11 @@
     <div class="grid-container">
       <div class="grid-row grid-gap footer-nav-top">
         <div class="grid-col-12 tablet:grid-col">
+          {% assign agencies = site.agencies %}
           <ul>
-            <li><a href="https://www.cdc.gov/">CDC.gov</a></li>
-            <li><a href="https://www.whitehouse.gov">WhiteHouse.gov</a></li>
-            <li><a href="https://www.fema.gov">FEMA.gov</a></li>
-            <li><a href="https://www.coronavirus.gov">Coronavirus.gov</a></li>
-            <li><a href="https://www.hhs.gov">HHS.gov</a></li>
+          {% for agency in agencies %}
+            <li><a href="{{ agency.link }}">{{ agency.title }}</a></li>
+          {% endfor %}
           </ul>
         </div>
         <div class="tablet:grid-col"></div>


### PR DESCRIPTION
Fixes #585

[PREVIEW](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/agency-auto-footer/)

- Autogenerates agency list in footer (from `_agencies` collection)

## Purpose
There are several manual steps in the content workflow. The purpose of this change is to preclude the manual curation of agency names and links in the site's footer. This change adds a `link` field to the `_agencies`' markdown files, and lists each agency and its respective link in the footer. The list will "keep itself up to date," so long as each agency has a properly formatted markdown file in the `_agencies` directory.