### PR TITLE
Remove DAP snippet

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,7 @@
+{% comment %} DAP unused, in favor of Google Tag Manager
 <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
 <script id="_fed_an_ua_tag"
   src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{site.dap_agency}}"></script>
+{% endcomment %}
 
 {% asset app.js %}


### PR DESCRIPTION
Remove DAP code, due to GTM usage superseding it. #218 

[Preview](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/remove-dap/)