### PR TITLE
Simply workflow by going back to one staging branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,13 @@
-_Promote changes._
+_Description of changes, including a reference to any relevant Github issues_
 
 Please confirm the following steps are completed:
 
 * [ ] Choose the appropriate target branch:
   * Content
-    * `preview-content` (approved content) <- *Content branch*
-    * `master` (production) <- `preview-content`
-  * Design/development
-    * `preview` (approved design) <- *Feature branch*
+    * `preview` (approved content) <- *Content branch*
     * `master` (production) <- `preview`
 * [ ] Assign an appropriate reviewer:
-  * *Content admin* for merge to `preview-content` (approved content)
-  * *Project lead* for merge to `preview` (approved design / behavior changes)
+  * *Content admin* or *Project lead* for merge to `preview` (approved content)
   * *Engineer* for merge to master (production)
 
 :sunglasses: [PREVIEW URL](<!-- ADD PREVIEW URL HERE -->)


### PR DESCRIPTION
I think we've confused matters too much by introducing separate staging branches for dev and content purposes, so let's make all our lives easier by going back to a single one.

:sunglasses: [PREVIEW URL](<!-- ADD PREVIEW URL HERE -->)
