### PR TITLE
Category chapters

### DIFF
--- a/_assets/js/app.js
+++ b/_assets/js/app.js
@@ -20,7 +20,6 @@
 
   const pageHashButtons = document.querySelectorAll(`${BUTTON}[set-page-hash]`);
   pageHashButtons.forEach(button => button.addEventListener('click', (event) => {
-    //document.location = '#' + event.target.id;
     document.location.replace('#' + event.target.id);
   }));
 })();

--- a/_assets/js/app.js
+++ b/_assets/js/app.js
@@ -17,6 +17,12 @@
     accordionButtons.forEach(a => a.setAttribute(EXPANDED, false));
     (target || accordionButtons[0]).setAttribute(EXPANDED, true);
   }
+
+  const pageHashButtons = document.querySelectorAll(`${BUTTON}[set-page-hash]`);
+  pageHashButtons.forEach(button => button.addEventListener('click', (event) => {
+    //document.location = '#' + event.target.id;
+    document.location.replace('#' + event.target.id);
+  }));
 })();
 
 //////////////////////////////////

--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -6,6 +6,7 @@
 <h2 class="usa-accordion__heading">
 <button id="{{ question.title | slugify }}"
     class="usa-accordion__button"
+    set-page-hash
     aria-controls="control-{{ question.title | slugify }}">
     {{ question.title }}
 </button>

--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -6,7 +6,6 @@
 <h2 class="usa-accordion__heading">
 <button id="{{ question.title | slugify }}"
     class="usa-accordion__button"
-    aria-expanded="true"
     aria-controls="control-{{ question.title | slugify }}">
     {{ question.title }}
 </button>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -17,7 +17,7 @@ layout: default
       {% if page.banner.display == true %}
       {% include alert-banner.html banner=page.banner %}
       {% endif %}
-      <div class="usa-accordion usa-accordion--bordered" aria-multiselectable=true>
+      <div class="usa-accordion usa-accordion--bordered" aria-multiselectable=false>
         {% assign promoted_in_category = category_questions | group_by:"promoted" | reverse %}
         {% for is_promoted in promoted_in_category %}
         {% for question in is_promoted.items %}

--- a/test/categories.html.test.js
+++ b/test/categories.html.test.js
@@ -58,3 +58,21 @@ test('shows a specific question instead of the first if it is passed as an ancho
   expect(questions[1].isOpen).toBe(true);
   expect(questions.filter(q => q.isOpen)).toHaveLength(1);
 });
+
+test('changes page hash on question click', async () => {
+  const allButtonIds = await page.$$eval('#main-content .usa-accordion__button', els => {
+    return els.map(el => el.id)
+  });
+  const ids = await page.$$eval('#main-content .usa-accordion__button[set-page-hash]', els => {
+    return els.map(el => el.id)
+  });
+
+  // All accordion buttons on the category pages should have the set-page-hash attribute
+  expect(allButtonIds.length).toBe(ids.length);
+
+  // Click events on accordion buttons should set the page URL to the button's hash
+  for (const id of ids) {
+    await page.click('#' + id);
+    expect(page.url().endsWith('#' + id)).toBe(true);
+  }
+});


### PR DESCRIPTION
Implements #744

On category pages:

* Use single-select accordions
* Update the current URL to include the question hash on click.

Note that the URL is updated without updating browser history.

This will support:

* bookmarking/sharing use cases
* allow analytic reports to track clicks via the URL change events, pending Google Tag Manager configuration by our analytics partners

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/category-chapters/)
