### PR TITLE
Add redirect support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-seo-tag'
   gem "jekyll-assets", "~> 3.0", ">= 3.0.12", group: :jekyll_plugins
+  gem "jekyll-redirect-from", "~> 0.16.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -30,3 +31,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", "~> 3.10"
 gem "rake"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       nokogiri (~> 1.8)
       pathutil (~> 0.16)
       sprockets (>= 3.3, < 4.1.beta)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sanity (1.6.0)
       jekyll (>= 3.1, < 5.0)
       pathutil (~> 0.16)
@@ -117,6 +119,7 @@ DEPENDENCIES
   html-proofer (~> 3.10)
   jekyll (~> 3.8)
   jekyll-assets (~> 3.0, >= 3.0.12)
+  jekyll-redirect-from (~> 0.16.0)
   jekyll-seo-tag
   jekyll-sitemap
   rake

--- a/_config.yml
+++ b/_config.yml
@@ -145,6 +145,7 @@ url: https://faq.coronavirus.gov
 plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 exclude:
   - package.json

--- a/_content/medications/are-there-any-vaccines.md
+++ b/_content/medications/are-there-any-vaccines.md
@@ -8,6 +8,8 @@ sources:
 - agency: fema
   url: https://www.fema.gov/coronavirus-rumor-control
 title: Are there any vaccines to prevent or medicines to treat COVID-19?
+redirect_from:
+  - /rumors/are-there-any-vaccines
 ---
 
 Currently, there are no Food and Drug Administration (FDA) approved drugs specifically for the treatment of COVID-19. Researchers are studying new drugs, and drugs that are already approved for other health conditions, as possible treatments for COVID-19. The Centers for Disease Control and Prevention has more information for health care providers about these potential treatments.


### PR DESCRIPTION
We have some old cached content from previously-named versions of some pages that still show . See #729

This PR adds the `jekyll-redirect-from` plugin, which adds the ability to do a client-side redirect via Javascript. Federalist does not support actual 301/302 redirects - see https://github.com/18F/federalist/issues/755 This plugin sets `<meta name="robots" content="noindex">` which should prevent search.gov from indexing the redirect files.

This branch adds a single redirect - [https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/add-redirects/rumors/are-there-any-vaccines/](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/add-redirects/rumors/are-there-any-vaccines/)

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/add-redirects/)
