### PR TITLE
(DONT MERGE) Experiment: Try search.gov results in type-ahead

### DIFF
--- a/scripts/components/type-ahead.js
+++ b/scripts/components/type-ahead.js
@@ -1,16 +1,20 @@
 import accessibleAutocomplete from 'accessible-autocomplete';
 
 import { debounce } from '../utils';
-import { doLocalSearch } from '../services/search';
+import { doSearchGovSearch } from '../services/search';
 
 const AUTOCOMPLETE_CONTAINER_CLASS = 'autocomplete_container';
 
-const highlight = (text, query) => {
+/*const highlight = (text, query) => {
   if (!query) {
     return;
   }
   let words = query.split(' ').filter(word => word.length);
   return text.replace(new RegExp('(\\b)(' + words.join('|') + ')(\\b)','ig'), '$1<strong>$2</strong>$3');
+};*/
+
+const highlight = (text) => {
+  return text.replace(/\uE000/g, '<strong>').replace(/\uE001/g, '</strong>');
 };
 
 export const initAutoComplete = function () {
@@ -25,7 +29,7 @@ export const initAutoComplete = function () {
   let currentQuery = null;
 
   const makeDebouncedRequest = debounce((query, completed) => {
-    doLocalSearch(query)
+    doSearchGovSearch(query)
       .then(response => completed(response.results.slice(0, 5)));
   }, 300);
 


### PR DESCRIPTION
As an experiment - this uses search.gov results rather than the Fuse.js local search, for the autocomplete functionality. Note that routed queries are not implemented, but this should give an idea of the UX. See #774 

Please confirm the following steps are completed:

* [ ] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [ ] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/search-results-dropdown/)
