### PR TITLE
HTML proofer - skip Twitter URLs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,10 @@ task :htmlproof do
 
   HTMLProofer.check_directory("./_site", {
     empty_alt_ignore: true,
+    url_ignore: [
+      # Ignore Twitter URLs - they tend to rate-limit CircleCI jobs
+      /^https:\/\/twitter.com\/.+/
+    ],
     url_swap: {
       # treat urls to faq.coronavirus.gov as local
       'https://faq.coronavirus.gov' => ''
@@ -16,8 +20,8 @@ task :htmlproof do
       :connecttimeout => 30,
       :timeout => 60
     },
-    :hydra => { 
-      :max_concurrency => 10 
+    :hydra => {
+      :max_concurrency => 10
     }
   }).run
 end

--- a/_content/support-for-business/where-should-a-small-business-go-to-find-help.md
+++ b/_content/support-for-business/where-should-a-small-business-go-to-find-help.md
@@ -11,4 +11,4 @@ title: Where should a small business go to find help in response to the Coronavi
   pandemic?
 ---
 
-Stay up to date with the U.S. Small Business Administration’s assistance at by visiting [www.sba.gov/coronavirus](http://www.sba.gov/coronavirus), following [@SBAgov](http://www.twitter.com/SBAGov) on Twitter, and subscribing to SBA’s e-updates via [www.sba.gov/updates](http://www.sba.gov/updates).
+Stay up to date with the U.S. Small Business Administration’s assistance at by visiting [www.sba.gov/coronavirus](http://www.sba.gov/coronavirus), following [@SBAgov](https://twitter.com/SBAGov) on Twitter, and subscribing to SBA’s e-updates via [www.sba.gov/updates](http://www.sba.gov/updates).


### PR DESCRIPTION
Due to Twitter rate-limiting (http 429) all requests from our CircleCI jobs, skip Twitter URLs on the HTML proofer tests. #831 

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](<!-- ADD PREVIEW URL HERE -->)
