### PR TITLE
Add BASE_URL constant for search service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   rake
-  sprockets (~> 3.7, >= 3.7.2)
+  sprockets (~> 3.7)
   tzinfo-data
 
 RUBY VERSION

--- a/scripts/services/search/constants.js
+++ b/scripts/services/search/constants.js
@@ -3,3 +3,4 @@ export const RESULTS_LIMIT = 25;
 export const SEARCHGOV_ENDPOINT = document.querySelector("meta[name='searchgov_endpoint']").content;
 export const SEARCHGOV_AFFILIATE = document.querySelector("meta[name='searchgov_affiliate']").content;
 export const SEARCHGOV_ACCESS_KEY = document.querySelector("meta[name='searchgov_access_key']").content;
+export const BASE_URL = document.querySelector("meta[name='baseurl']").content;


### PR DESCRIPTION
This is a hotfix for an error deployed this morning.

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](<!-- ADD PREVIEW URL HERE -->)
