### PR TITLE
WIP: Spell out all agency names (titles) in agency files

### DIFF
--- a/_agencies/cdc.md
+++ b/_agencies/cdc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: cdc
-title: "CDC"
+title: "Centers for Disease Control and Prevention"
 sitemap: false
 ---

--- a/_agencies/dhs.md
+++ b/_agencies/dhs.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: dhs
-title: "DHS"
+title: "U.S. Department of Homeland Security"
 sitemap: false
 ---

--- a/_agencies/fcc.md
+++ b/_agencies/fcc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: fcc
-title: "FCC"
+title: "Federal Communications Commission"
 sitemap: false
 ---

--- a/_agencies/fda.md
+++ b/_agencies/fda.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: fda
-title: "FDA"
+title: "U.S. Food & Drug Administration"
 sitemap: false
 ---

--- a/_agencies/fema.md
+++ b/_agencies/fema.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: fema
-title: "FEMA"
+title: "Federal Emergency Management Agency"
 sitemap: false
 ---

--- a/_agencies/ftc.md
+++ b/_agencies/ftc.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: ftc
-title: "FTC"
+title: "Federal Trade Commission"
 sitemap: false
 ---

--- a/_agencies/irs.md
+++ b/_agencies/irs.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: irs
-title: "IRS"
+title: "Internal Revenue Services"
 sitemap: false
 ---

--- a/_agencies/sba.md
+++ b/_agencies/sba.md
@@ -2,6 +2,6 @@
 layout: agency
 name: sba
 permalink: /agency/sba/
-title: "Small Business Administration"
+title: "U.S. Small Business Administration"
 sitemap: false
 ---

--- a/_agencies/treasury.md
+++ b/_agencies/treasury.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: treasury
-title: "Treasury"
+title: "U.S. Department of the Treasury"
 sitemap: false
 ---

--- a/_agencies/usda.md
+++ b/_agencies/usda.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: usda
-title: "USDA"
+title: "U.S. Department of Agriculture"
 sitemap: false
 ---

--- a/_agencies/va.md
+++ b/_agencies/va.md
@@ -1,6 +1,6 @@
 ---
 layout: agency
 name: va
-title: "VA"
+title: "U.S. Department of Veterans Affairs"
 sitemap: false
 ---

--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -14,7 +14,7 @@
 <div id="control-{{ question.title | slugify }}" class="usa-accordion__content usa-prose">
     <p>{{ question.content | markdownify }}</p>
 
-    <p class="question-meta">Last updated {{ question.date | date:  "%B %d, %Y" }}
+    <p class="question-meta">Last updated {{ question.date | date:  "%B %d, %Y" }}<br/>
     {% include sources.html %}
     </p>
 </div>

--- a/_includes/sources.html
+++ b/_includes/sources.html
@@ -1,4 +1,4 @@
-|<cite> Source{% if question.sources.size > 1 %}s{% endif %}:
+<cite>Source{% if question.sources.size > 1 %}s{% endif %}:
     {%- for source in question.sources -%}
         {% assign current_source = site.agencies | where:"name", source.agency | first %}
         <a href="{{ source.url }}" class="usa-link">


### PR DESCRIPTION
Spelled out full agency names in the title attribute of the agency files, so the full name displays in the source info (footer) of each FAQ.

Please review the appearance on longer agency names that linebreak...and questions with multiple sources (see example links below). Do we want to consider the agency source being on a new line? Anything else we should consider/unanticipated impacts @danielnaab ?

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/spell-out-agency-names-2020-07-06/)
- [Line break example](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/spell-out-agency-names-2020-07-06/spread/if-i-have-recovered-will-i-be-immune/)
- [Multiple source example](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/spell-out-agency-names-2020-07-06/financial-help/is-the-government-delaying-tax-day/)
