### PR TITLE
Update questions API to use new categories

### DIFF
--- a/api/v1/questions.json
+++ b/api/v1/questions.json
@@ -3,7 +3,7 @@ layout: null
 ---
 [
   {%- for content in site.content %}
-  {%- assign category = site.categories | where: 'name', content.categories[0] | first %}
+  {%- assign category = site.categories | for_question: content.slug | first %}
   {
     "question_url": "{{ site.url }}/{{ content.slug | downcase }}/",
     "title": "{{ content.title | replace: '"', '\"' }}",

--- a/api/v2/questions.json
+++ b/api/v2/questions.json
@@ -9,7 +9,7 @@ layout: null
     "answer": "{{ content.content | strip_html | strip_newlines | remove_chars | escape }}",
     "answer_html": "{{ content.content | strip_newlines | replace: '"', '\"' }}",
     "updated_at": "{{ content.date | date: '%Y-%m-%d' }}",
-    "categories": [{% for question_category in content.categories %}{%- assign category = site.categories | where: 'name', question_category | first %}{
+    "categories": [{% assign question_categories = site.categories | for_question: content.slug %}{%- for category in question_categories %}{
       "title": "{{ category.title }}",
       "category_url": "{{ site.url }}/{{ category.name | downcase }}/"
     }{% unless forloop.last %}, {% endunless %}{% endfor %}],


### PR DESCRIPTION
Follow-on PR to #940 - add categories to API endpoints.

[api v1](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/questions-v2-categories/api/v1/questions.json)
[api v2](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/questions-v2-categories/api/v2/questions.json)

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/questions-v2-categories/)
