### PR TITLE
Update top boxes to go to categories

### DIFF
--- a/_categories/protect-yourself.md
+++ b/_categories/protect-yourself.md
@@ -10,8 +10,8 @@ owner: CDC
 questions:
 - how-can-i-protect-myself
 - does-cdc-recommend-facemasks
-- if-i-need-to-evacuate-my-home-during-the-covid19-pandemic
 - how-do-i-prepare-for-hurricane-season-during-covid19
+- if-i-need-to-evacuate-my-home-during-the-covid19-pandemic
 - what-should-i-do-if-i-had-close-contact-with-someone-who-has-covid-19
 - what-should-people-at-higher-risk-of-serious-illness-with-covid-19-do
 - how-to-keep-myself-safe-when-i-go-grocery-store

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: Someone in my house has COVID-19, what do I do?
+      question: If someone in my house gets sick with COVID-19, what should I do? 
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: What do I do if someone in my house gets COVID-19?
+      question: If someone in my house has COVID-19, what should I do?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: What should I do if someone in my home gets COVID-19?
+      question: What should I do if someone in my house has COVID-19?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: What should I do if someone in my house has COVID-19?
+      question: What do I do if someone in my house gets COVID-19?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: If someone in my house gets sick with COVID-19, what should I do?
+      question: Someone in my house has COVID-19, what do I do?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: If someone in my house has COVID-19, what should I do?
+      question: If someone in my house gets sick with COVID-19, what should I do?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -49,6 +49,6 @@ questions_box_2:
     - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
       question: Do I need to get tested?
     - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
-      question: What should I do if someone in my house gets COVID-19?
+      question: What should I do if someone in my home gets COVID-19?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/

--- a/_data/homepage_promotion.yml
+++ b/_data/homepage_promotion.yml
@@ -21,7 +21,7 @@ top_questions:
     link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
     question: Should I get tested?
   - icon: globe
-    link: /how-does-the-virus-spread
+    link: "/spread/#how-does-the-virus-spread"
     question: How does it spread?
   - icon: money
     link: /financial-help
@@ -34,9 +34,9 @@ top_questions:
     question: Can I travel?
 questions_box_1:
   questions:
-    - link: /if-i-have-recovered-will-i-be-immune
+    - link: "/spread/#if-i-have-recovered-from-covid-19-will-i-be-immune-to-it-i-e-can-i-get-it-twice"
       question: If I recovered from COVID-19, will I be immune?
-    - link: /does-cdc-recommend-facemasks/
+    - link: "/protect-yourself/#does-cdc-recommend-the-use-of-facemasks-or-face-coverings-to-prevent-covid-19"
       question: Does CDC recommend the use of facemasks?
     - link: /basics/#how-can-i-manage-anxiety-and-stress
       question: How can I manage anxiety and stress?
@@ -44,12 +44,11 @@ questions_box_1:
   view_all_link: /protect-yourself/
 questions_box_2:
   questions:
-    - link: >-
-        /what-are-the-symptoms-and-complications-that-covid-19-can-cause
+    - link: "/symptoms-and-testing/#what-are-the-symptoms-that-covid-19-can-cause"
       question: What are the symptoms of COVID-19?
-    - link: "/should-i-be-tested-for-covid-19"
-      question: Should I get tested?
-    - link: "/if-someone-in-my-house-gets-sick"
-      question: What should I do if someone in my house gets sick with COVID-19?
+    - link: "/symptoms-and-testing/#should-i-be-tested-for-covid-19"
+      question: Do I need to get tested?
+    - link: "/keeping-home-safe/#what-should-i-do-if-someone-in-my-house-gets-sick-with-covid-19" 
+      question: What should I do if someone in my house gets COVID-19?
   title: What to do *if you feel sick*
   view_all_link: /symptoms-and-testing/


### PR DESCRIPTION
Updated entries in blue and gray boxes to go to category pages and not to specific questions.

Blue box
- How does it spread? 

Protect self gray box

- If I recovered from COVID-19, will I be immune? 
- Does CDC recommend the use of facemasks? 

Feel sick gray box
- What are the symptoms of COVID-19? 
- Should I get tested? and re-labeled to Do I need to get tested?
- What should I do if someone in my house gets sick with COVID-19? and re-labeled to If someone in my house gets sick with  COVID-19, what should I do?

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `master` (production) <- `preview`
* [ ] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/update-homepage-boxes-20200805/)
