### PR TITLE
Single question page tweaks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@
 # Be sure to edit the values below
 ##########################################################################################
 
-title: COVID-19 Answers
+title: Coronavirus FAQ
 logo_alt: Home - Find answers about Coronavirus (COVID-19) from across the U.S. government.
 email: contact@example.gov
 description: >- # this means to ignore newlines until "baseurl:"

--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -13,9 +13,5 @@
 </button>
 </h2>
 <div id="control-{{ question.title | slugify }}" class="usa-accordion__content usa-prose">
-    <p>{{ question.content | markdownify }}</p>
-
-    <p class="question-meta">Last updated {{ question.date | date:  "%B %d, %Y" }}<br/>
-    {% include sources.html %}
-    </p>
+    {% include question-content.html question=question %}
 </div>

--- a/_includes/question-content.html
+++ b/_includes/question-content.html
@@ -1,0 +1,11 @@
+{% comment %}
+    Content section of a question, used on single pages and category accordions.
+{% endcomment %}
+
+{% assign question = include.question %}
+
+<p>{{ question.content | markdownify }}</p>
+
+<p class="question-meta">Last updated {{ question.date | date:  "%B %d, %Y" }}<br/>
+{% include sources.html %}
+</p>

--- a/_includes/title.html
+++ b/_includes/title.html
@@ -1,5 +1,5 @@
 {%- if page.title -%}
-    {{ page.title }} - {{site.title}}
+    {{ page.title }} | {{site.title}}
 {%- else -%}
     {{site.title}}
 {%- endif -%}

--- a/_layouts/agency.html
+++ b/_layouts/agency.html
@@ -32,7 +32,7 @@ sitemap: false
                   <span class="text-gray-50"> {{ question.date | date: "%B %d, %Y" }}</span>
                   {% assign question_categories = site.categories | for_question: question.slug %}
                   / {% for category in question_categories %}
-                    <a href="/{{ category.slug }}">{{ category.title }}</a>
+                    <a href="{{ site.baseurl }}/{{ category.slug }}">{{ category.title }}</a>
                     {% if forloop.last == false %},{% endif %}
                   {% endfor %}
                 </li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,8 +16,7 @@ This is the template for single-question pages.
         <p>
           {% if question_categories.size == 1 %}Category:{% else %}Categories:{% endif %}
           {% for category in question_categories %}
-            <a href="/{{ category.slug }}">{{ category.title }}</a>
-            {% if forloop.last == false %},{% endif %}
+            <a href="{{ site.baseurl }}/{{ category.slug }}">{{ category.title }}</a>{% if forloop.last == false %},{% endif %}
           {% endfor %}
         </p>
       </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ This is the template for single-question pages.
       <div class="usa-prose">
         {% include question-content.html question=page %}
         <p>
-          {% if question_categories.size == 1 %}Category:{% else %}Categories:{% endif %}
+          See also:
           {% for category in question_categories %}
             <a href="{{ site.baseurl }}/{{ category.slug }}">{{ category.title }}</a>{% if forloop.last == false %},{% endif %}
           {% endfor %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,13 +6,20 @@ layout: default
 This is the template for single-question pages.
 {% endcomment %}
 
-
+{% assign question_categories = site.categories | for_question: page.slug %}
 <div class="usa-layout-docs usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <h1>{{ page.title }}</h1>
       <div class="usa-prose">
         {% include question-content.html question=page %}
+        <p>
+          {% if question_categories.size == 1 %}Category:{% else %}Categories:{% endif %}
+          {% for category in question_categories %}
+            <a href="/{{ category.slug }}">{{ category.title }}</a>
+            {% if forloop.last == false %},{% endif %}
+          {% endfor %}
+        </p>
       </div>
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,16 +3,16 @@ layout: default
 ---
 
 {% comment %}
-This is used in blog posts. The index page can be found at blog/index.html
+This is the template for single-question pages.
 {% endcomment %}
+
 
 <div class="usa-layout-docs usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
-        <div class="usa-accordion usa-accordion--bordered" aria-multiselectable=true>
-          {% include accordion.html accordion_content=page %}
-         </div>
+      <h1>{{ page.title }}</h1>
+      <div class="usa-prose">
+        {% include question-content.html question=page %}
       </div>
     </div>
   </div>

--- a/styles/_posts.scss
+++ b/styles/_posts.scss
@@ -1,5 +1,8 @@
 .breadcrumb {
   padding: units(2.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 div.usa-layout-docs.usa-section {


### PR DESCRIPTION
Implements #983

* Remove accordion from single questions page
* Breadcrumb styling
* Update site title
* Add categories after single page question answer

Here's question with a long title that demos the breadcrumb styling: https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/single-question-page-tweaks/calls-to-small-businesses-promising-quick-financial-relief/

Here's a question with two categories that demos multi-cat styling: https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/single-question-page-tweaks/should-i-trust-ads-for-products-to-prevent-treat-cure-covid-19/


Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `main` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](https://cg-dae9433e-23a0-46d7-bafb-dc79d2d3756c.app.cloud.gov/preview/18f/cv_faq/single-question-page-tweaks/calls-to-small-businesses-promising-quick-financial-relief/)
