### PR TITLE
Update redirects

### DIFF
--- a/_categories/disinfecting-sanitizing.md
+++ b/_categories/disinfecting-sanitizing.md
@@ -27,5 +27,6 @@ redirect_from:
  - /should-outdoor-playgrounds-be-cleaned-and-disinfected/
  - /funerals/what-do-funeral-home-workers-need-to-know/
  - /what-do-funeral-home-workers-need-to-know/
+ - /how-long-do-companies-need-to-close-for-disinfection-after-an-exposure/
 title: Disinfecting and sanitizing
 ---

--- a/_content/spread-transmission/handle-body-someone-who-died.md
+++ b/_content/spread-transmission/handle-body-someone-who-died.md
@@ -2,7 +2,7 @@
 date: September 28, 2020
 excerpt: Safely handle body of someone who died of COVID
 layout: post
-redirect-from:
+redirect_from:
 - /funerals/am-i-at-risk-touch-body/
 - /am-i-at-risk-touch-body/
 - /funerals/how-to-safely-handle-belongings-of-someone-died-from-covid-19/

--- a/_content/travel/can-american-citizen-return-to-us.md
+++ b/_content/travel/can-american-citizen-return-to-us.md
@@ -4,6 +4,7 @@ excerpt: 'Travel: Returning from travel'
 layout: post
 redirect_from:
 - /travel/can-american-citizen-return-to-us/
+- /travel/can-american-citizen-return-recently-traveled/
 sources:
 - agency: dhs
   url: https://www.dhs.gov/coronavirus/protecting-air-travelers-and-american-public


### PR DESCRIPTION
Redirect markdown syntax not correct in handle-body-someone-who-died

Added 2 based upon GA found 404s in disinfecting-and-sanitizing and can-american-citizen-return-to-us

_Description of changes, including a reference to any relevant Github issues_

Please confirm the following steps are completed:

* [x] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `main` (production) <- `preview`
* [x] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: 
Redirects test on preview

- [how-long-do-companies-need-to-close-for-disinfection-after-an-exposure](https://demo-er2epz2vb.18f.gov/how-long-do-companies-need-to-close-for-disinfection-after-an-exposure)   redirects to https://faq.coronavirus.gov/disinfecting-sanitizing /
- [funerals/am-i-at-risk-touch-body](https://demo-er2epz2vb.18f.gov/funerals/am-i-at-risk-touch-body)   redirects to https://faq.coronavirus.gov/handle-body-someone-who-died /
- [am-i-at-risk-touch-body](https://demo-er2epz2vb.18f.gov/am-i-at-risk-touch-body)   redirects to https://faq.coronavirus.gov/handle-body-someone-who-died /
- [funerals/how-to-safely-handle-belongings-of-someone-died-from-covid-19](https://demo-er2epz2vb.18f.gov/funerals/how-to-safely-handle-belongings-of-someone-died-from-covid-19)   redirects to https://faq.coronavirus.gov/handle-body-someone-who-died /
- [travel/can-american-citizen-return-recently-traveled](https://demo-er2epz2vb.18f.gov/travel/can-american-citizen-return-recently-traveled)   redirects to https://faq.coronavirus.gov/can-american-citizen-return-to-us /