### PR TITLE
Invalidate CircleCI node_modules cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,11 @@ jobs:
       - image: circleci/ruby:2.6.6-node-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v2-npm-{{ checksum "package-lock.json" }}
-            - v2-npm-
+      # Temporary to allow upgrading to node v14, remove after 11-6-2020
+      # - restore_cache:
+      #     keys:
+      #       - v2-npm-{{ checksum "package-lock.json" }}
+      #       - v2-npm-
       - run: npm install
       - save_cache:
           key: v2-npm-{{ checksum "package-lock.json" }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "coronavirus-faq", 
+  "name": "coronavirus-faq",
   "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "coronavirus-faq",
+  "name": "coronavirus-faq", 
   "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
_Description of changes, including a reference to any relevant Github issues_

Please confirm the following steps are completed:

* [ ] Choose the appropriate target branch:
  * Content
    * `preview` (approved content) <- *Content branch*
    * `main` (production) <- `preview`
* [ ] Assign an appropriate reviewer:
  * *Content admin* or *Project lead* for merge to `preview` (approved content)
  * *Engineer* for merge to master (production)

:sunglasses: [PREVIEW URL](<!-- ADD PREVIEW URL HERE -->)

Issue: *The docker container upgraded node from v12 to v14 between builds causing the cached node_modules to be incompatible with v14.*